### PR TITLE
grammar: detect `format` directives

### DIFF
--- a/src/grammar.json
+++ b/src/grammar.json
@@ -30,7 +30,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "comment_multiline"
+          "name": "block_comment"
         }
       ]
     },
@@ -51,48 +51,37 @@
         "value": "(;).*\\n?"
       }
     },
-    "comment_multiline": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "TOKEN",
-          "content": {
+    "block_comment": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
             "type": "STRING",
             "value": "#|"
-          }
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "PATTERN",
-                "value": "[^|#]+"
-              },
-              {
-                "type": "PATTERN",
-                "value": "#[^|]"
-              },
-              {
-                "type": "PATTERN",
-                "value": "[^#]\\|"
-              },
-              {
-                "type": "PATTERN",
-                "value": "[\\n\\r]+"
-              }
-            ]
-          }
-        },
-        {
-          "type": "TOKEN",
-          "content": {
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "PATTERN",
+                  "value": "[^|]"
+                },
+                {
+                  "type": "PATTERN",
+                  "value": "\\|[^#]"
+                }
+              ]
+            }
+          },
+          {
             "type": "STRING",
             "value": "|#"
           }
-        }
-      ]
+        ]
+      }
     },
     "_form": {
       "type": "CHOICE",
@@ -331,51 +320,459 @@
         }
       ]
     },
-    "str_lit": {
-      "type": "TOKEN",
+    "_format_token": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "TOKEN",
+            "content": {
+              "type": "PREC",
+              "value": 10,
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "PATTERN",
+                        "value": "[+-]"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "#x"
+                          },
+                          {
+                            "type": "REPEAT1",
+                            "content": {
+                              "type": "PATTERN",
+                              "value": "[0-9a-fA-F]"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "#b"
+                          },
+                          {
+                            "type": "REPEAT1",
+                            "content": {
+                              "type": "PATTERN",
+                              "value": "[0-1]"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "REPEAT1",
+                            "content": {
+                              "type": "PATTERN",
+                              "value": "[0-9]"
+                            }
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "."
+                                  },
+                                  {
+                                    "type": "REPEAT",
+                                    "content": {
+                                      "type": "PATTERN",
+                                      "value": "[0-9]"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "REPEAT1",
+                            "content": {
+                              "type": "PATTERN",
+                              "value": "[0-9]"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "named": true,
+          "value": "num_lit"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "'"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "."
+              },
+              "named": true,
+              "value": "char_lit"
+            }
+          ]
+        }
+      ]
+    },
+    "format_prefix_parameters": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "v"
+        },
+        {
+          "type": "STRING",
+          "value": "V"
+        },
+        {
+          "type": "STRING",
+          "value": "#"
+        }
+      ]
+    },
+    "format_modifiers": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_format_token"
+              },
+              {
+                "type": "STRING",
+                "value": ","
+              }
+            ]
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "@"
+            },
+            {
+              "type": "STRING",
+              "value": "@:"
+            },
+            {
+              "type": "STRING",
+              "value": ":"
+            },
+            {
+              "type": "STRING",
+              "value": ":@"
+            }
+          ]
+        }
+      ]
+    },
+    "format_directive_type": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "repetitions",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_format_token"
+                  }
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "~"
+                },
+                {
+                  "type": "STRING",
+                  "value": "%"
+                },
+                {
+                  "type": "STRING",
+                  "value": "&"
+                },
+                {
+                  "type": "STRING",
+                  "value": "|"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "PATTERN",
+          "value": "[cC]"
+        },
+        {
+          "type": "PATTERN",
+          "value": "\\^"
+        },
+        {
+          "type": "STRING",
+          "value": "\n"
+        },
+        {
+          "type": "STRING",
+          "value": "\r"
+        },
+        {
+          "type": "PATTERN",
+          "value": "[pP]"
+        },
+        {
+          "type": "PATTERN",
+          "value": "[iI]"
+        },
+        {
+          "type": "PATTERN",
+          "value": "[wW]"
+        },
+        {
+          "type": "PATTERN",
+          "value": "[aA]"
+        },
+        {
+          "type": "STRING",
+          "value": "_"
+        },
+        {
+          "type": "PATTERN",
+          "value": "[()]"
+        },
+        {
+          "type": "PATTERN",
+          "value": "[{}]"
+        },
+        {
+          "type": "PATTERN",
+          "value": "[\\[\\]]"
+        },
+        {
+          "type": "PATTERN",
+          "value": "[<>]"
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "numberOfArgs",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_format_token"
+              }
+            },
+            {
+              "type": "STRING",
+              "value": "*"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "?"
+        },
+        {
+          "type": "STRING",
+          "value": "Newline"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_format_token"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  }
+                ]
+              }
+            },
+            {
+              "type": "PATTERN",
+              "value": "[$rRbBdDgGxXeEoOsStTfF]"
+            }
+          ]
+        }
+      ]
+    },
+    "format_specifier": {
+      "type": "PREC_LEFT",
+      "value": 0,
       "content": {
         "type": "SEQ",
         "members": [
           {
             "type": "STRING",
-            "value": "\""
+            "value": "~"
           },
           {
-            "type": "REPEAT",
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "format_prefix_parameters"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "format_modifiers"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "PREC",
+            "value": 5,
             "content": {
-              "type": "PATTERN",
-              "value": "[^\"\\\\]"
+              "type": "SYMBOL",
+              "name": "format_directive_type"
             }
-          },
-          {
-            "type": "REPEAT",
-            "content": {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "\\"
-                },
-                {
-                  "type": "PATTERN",
-                  "value": "."
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[^\"\\\\]"
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "type": "STRING",
-            "value": "\""
           }
         ]
       }
+    },
+    "str_lit": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\""
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "PREC",
+                  "value": 1,
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\\\~\"]+"
+                  }
+                }
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "PATTERN",
+                      "value": "\\\\."
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "SYMBOL",
+                "name": "format_specifier"
+              }
+            ]
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "~"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "\""
+        }
+      ]
     },
     "char_lit": {
       "type": "TOKEN",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1,8 +1,106 @@
 [
   {
-    "type": "comment_multiline",
+    "type": "format_directive_type",
+    "named": true,
+    "fields": {
+      "numberOfArgs": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "'",
+            "named": false
+          },
+          {
+            "type": "char_lit",
+            "named": true
+          },
+          {
+            "type": "num_lit",
+            "named": true
+          }
+        ]
+      },
+      "repetitions": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "'",
+            "named": false
+          },
+          {
+            "type": "char_lit",
+            "named": true
+          },
+          {
+            "type": "num_lit",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "char_lit",
+          "named": true
+        },
+        {
+          "type": "num_lit",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "format_modifiers",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "char_lit",
+          "named": true
+        },
+        {
+          "type": "num_lit",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "format_prefix_parameters",
     "named": true,
     "fields": {}
+  },
+  {
+    "type": "format_specifier",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "format_directive_type",
+          "named": true
+        },
+        {
+          "type": "format_modifiers",
+          "named": true
+        },
+        {
+          "type": "format_prefix_parameters",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "kwd_lit",
@@ -114,15 +212,20 @@
       "required": false,
       "types": [
         {
-          "type": "comment",
+          "type": "block_comment",
           "named": true
         },
         {
-          "type": "comment_multiline",
+          "type": "comment",
           "named": true
         }
       ]
     }
+  },
+  {
+    "type": "num_lit",
+    "named": true,
+    "fields": {}
   },
   {
     "type": "quasi_quoting_lit",
@@ -198,11 +301,11 @@
       "required": false,
       "types": [
         {
-          "type": "comment",
+          "type": "block_comment",
           "named": true
         },
         {
-          "type": "comment_multiline",
+          "type": "comment",
           "named": true
         }
       ]
@@ -282,11 +385,11 @@
       "required": false,
       "types": [
         {
-          "type": "comment",
+          "type": "block_comment",
           "named": true
         },
         {
-          "type": "comment_multiline",
+          "type": "comment",
           "named": true
         }
       ]
@@ -301,6 +404,10 @@
       "required": false,
       "types": [
         {
+          "type": "block_comment",
+          "named": true
+        },
+        {
           "type": "bool_lit",
           "named": true
         },
@@ -310,10 +417,6 @@
         },
         {
           "type": "comment",
-          "named": true
-        },
-        {
-          "type": "comment_multiline",
           "named": true
         },
         {
@@ -354,6 +457,21 @@
         },
         {
           "type": "unquoting_lit",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "str_lit",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "format_specifier",
           "named": true
         }
       ]
@@ -449,11 +567,11 @@
       "required": false,
       "types": [
         {
-          "type": "comment",
+          "type": "block_comment",
           "named": true
         },
         {
-          "type": "comment_multiline",
+          "type": "comment",
           "named": true
         }
       ]
@@ -533,18 +651,38 @@
       "required": false,
       "types": [
         {
-          "type": "comment",
+          "type": "block_comment",
           "named": true
         },
         {
-          "type": "comment_multiline",
+          "type": "comment",
           "named": true
         }
       ]
     }
   },
   {
-    "type": "#|",
+    "type": "\n",
+    "named": false
+  },
+  {
+    "type": "\r",
+    "named": false
+  },
+  {
+    "type": "\"",
+    "named": false
+  },
+  {
+    "type": "#",
+    "named": false
+  },
+  {
+    "type": "%",
+    "named": false
+  },
+  {
+    "type": "&",
     "named": false
   },
   {
@@ -560,6 +698,10 @@
     "named": false
   },
   {
+    "type": "*",
+    "named": false
+  },
+  {
     "type": ",",
     "named": false
   },
@@ -572,8 +714,44 @@
     "named": false
   },
   {
+    "type": ":@",
+    "named": false
+  },
+  {
+    "type": ";",
+    "named": false
+  },
+  {
+    "type": "?",
+    "named": false
+  },
+  {
+    "type": "@",
+    "named": false
+  },
+  {
+    "type": "@:",
+    "named": false
+  },
+  {
+    "type": "Newline",
+    "named": false
+  },
+  {
+    "type": "V",
+    "named": false
+  },
+  {
+    "type": "_",
+    "named": false
+  },
+  {
     "type": "`",
     "named": false
+  },
+  {
+    "type": "block_comment",
+    "named": true
   },
   {
     "type": "bool_lit",
@@ -596,19 +774,19 @@
     "named": true
   },
   {
-    "type": "num_lit",
-    "named": true
-  },
-  {
-    "type": "str_lit",
-    "named": true
-  },
-  {
     "type": "sym_name",
     "named": true
   },
   {
-    "type": "|#",
+    "type": "v",
+    "named": false
+  },
+  {
+    "type": "|",
+    "named": false
+  },
+  {
+    "type": "~",
     "named": false
   }
 ]

--- a/src/parser.c
+++ b/src/parser.c
@@ -6,73 +6,134 @@
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 37
-#define LARGE_STATE_COUNT 15
-#define SYMBOL_COUNT 41
+#define STATE_COUNT 62
+#define LARGE_STATE_COUNT 2
+#define SYMBOL_COUNT 74
 #define ALIAS_COUNT 0
-#define TOKEN_COUNT 24
+#define TOKEN_COUNT 50
 #define EXTERNAL_TOKEN_COUNT 0
-#define FIELD_COUNT 5
-#define MAX_ALIAS_SEQUENCE_LENGTH 3
-#define PRODUCTION_ID_COUNT 10
+#define FIELD_COUNT 7
+#define MAX_ALIAS_SEQUENCE_LENGTH 4
+#define PRODUCTION_ID_COUNT 13
 
 enum {
   sym__ws = 1,
   sym_comment = 2,
-  anon_sym_POUND_PIPE = 3,
-  aux_sym_comment_multiline_token1 = 4,
-  aux_sym_comment_multiline_token2 = 5,
-  aux_sym_comment_multiline_token3 = 6,
-  aux_sym_comment_multiline_token4 = 7,
-  anon_sym_PIPE_POUND = 8,
-  sym_num_lit = 9,
-  aux_sym__kwd_unqualified_token1 = 10,
-  anon_sym_COLON = 11,
-  sym_str_lit = 12,
-  sym_char_lit = 13,
-  sym_null_lit = 14,
-  sym_bool_lit = 15,
-  anon_sym_SLASH = 16,
-  aux_sym__sym_unqualified_token1 = 17,
-  anon_sym_LPAREN = 18,
-  anon_sym_RPAREN = 19,
-  anon_sym_SQUOTE = 20,
-  anon_sym_BQUOTE = 21,
-  anon_sym_COMMA_AT = 22,
-  anon_sym_COMMA = 23,
-  sym_source = 24,
-  sym__gap = 25,
-  sym_comment_multiline = 26,
-  sym__form = 27,
-  sym_kwd_lit = 28,
-  sym__kwd_marker = 29,
-  sym_sym_lit = 30,
-  sym_list_lit = 31,
-  sym__bare_list_lit = 32,
-  sym_quoting_lit = 33,
-  sym_quasi_quoting_lit = 34,
-  sym_unquote_splicing_lit = 35,
-  sym_unquoting_lit = 36,
-  aux_sym_source_repeat1 = 37,
-  aux_sym_comment_multiline_repeat1 = 38,
-  aux_sym__bare_list_lit_repeat1 = 39,
-  aux_sym_quoting_lit_repeat1 = 40,
+  sym_block_comment = 3,
+  aux_sym_num_lit_token1 = 4,
+  aux_sym__kwd_unqualified_token1 = 5,
+  anon_sym_COLON = 6,
+  anon_sym_SQUOTE = 7,
+  aux_sym__format_token_token1 = 8,
+  anon_sym_v = 9,
+  anon_sym_V = 10,
+  anon_sym_POUND = 11,
+  anon_sym_COMMA = 12,
+  anon_sym_AT = 13,
+  anon_sym_AT_COLON = 14,
+  anon_sym_COLON_AT = 15,
+  anon_sym_TILDE = 16,
+  anon_sym_PERCENT = 17,
+  anon_sym_AMP = 18,
+  anon_sym_PIPE = 19,
+  aux_sym_format_directive_type_token1 = 20,
+  aux_sym_format_directive_type_token2 = 21,
+  anon_sym_LF = 22,
+  anon_sym_CR = 23,
+  aux_sym_format_directive_type_token3 = 24,
+  aux_sym_format_directive_type_token4 = 25,
+  aux_sym_format_directive_type_token5 = 26,
+  aux_sym_format_directive_type_token6 = 27,
+  anon_sym__ = 28,
+  aux_sym_format_directive_type_token7 = 29,
+  aux_sym_format_directive_type_token8 = 30,
+  aux_sym_format_directive_type_token9 = 31,
+  aux_sym_format_directive_type_token10 = 32,
+  anon_sym_SEMI = 33,
+  anon_sym_STAR = 34,
+  anon_sym_QMARK = 35,
+  anon_sym_Newline = 36,
+  aux_sym_format_directive_type_token11 = 37,
+  anon_sym_DQUOTE = 38,
+  aux_sym_str_lit_token1 = 39,
+  aux_sym_str_lit_token2 = 40,
+  sym_char_lit = 41,
+  sym_null_lit = 42,
+  sym_bool_lit = 43,
+  anon_sym_SLASH = 44,
+  aux_sym__sym_unqualified_token1 = 45,
+  anon_sym_LPAREN = 46,
+  anon_sym_RPAREN = 47,
+  anon_sym_BQUOTE = 48,
+  anon_sym_COMMA_AT = 49,
+  sym_source = 50,
+  sym__gap = 51,
+  sym__form = 52,
+  sym_num_lit = 53,
+  sym_kwd_lit = 54,
+  sym__kwd_marker = 55,
+  sym__format_token = 56,
+  sym_format_prefix_parameters = 57,
+  sym_format_modifiers = 58,
+  sym_format_directive_type = 59,
+  sym_format_specifier = 60,
+  sym_str_lit = 61,
+  sym_sym_lit = 62,
+  sym_list_lit = 63,
+  sym__bare_list_lit = 64,
+  sym_quoting_lit = 65,
+  sym_quasi_quoting_lit = 66,
+  sym_unquote_splicing_lit = 67,
+  sym_unquoting_lit = 68,
+  aux_sym_source_repeat1 = 69,
+  aux_sym_format_modifiers_repeat1 = 70,
+  aux_sym_str_lit_repeat1 = 71,
+  aux_sym__bare_list_lit_repeat1 = 72,
+  aux_sym_quoting_lit_repeat1 = 73,
 };
 
 static const char * const ts_symbol_names[] = {
   [ts_builtin_sym_end] = "end",
   [sym__ws] = "_ws",
   [sym_comment] = "comment",
-  [anon_sym_POUND_PIPE] = "#|",
-  [aux_sym_comment_multiline_token1] = "comment_multiline_token1",
-  [aux_sym_comment_multiline_token2] = "comment_multiline_token2",
-  [aux_sym_comment_multiline_token3] = "comment_multiline_token3",
-  [aux_sym_comment_multiline_token4] = "comment_multiline_token4",
-  [anon_sym_PIPE_POUND] = "|#",
-  [sym_num_lit] = "num_lit",
+  [sym_block_comment] = "block_comment",
+  [aux_sym_num_lit_token1] = "num_lit_token1",
   [aux_sym__kwd_unqualified_token1] = "kwd_name",
   [anon_sym_COLON] = ":",
-  [sym_str_lit] = "str_lit",
+  [anon_sym_SQUOTE] = "'",
+  [aux_sym__format_token_token1] = "char_lit",
+  [anon_sym_v] = "v",
+  [anon_sym_V] = "V",
+  [anon_sym_POUND] = "#",
+  [anon_sym_COMMA] = ",",
+  [anon_sym_AT] = "@",
+  [anon_sym_AT_COLON] = "@:",
+  [anon_sym_COLON_AT] = ":@",
+  [anon_sym_TILDE] = "~",
+  [anon_sym_PERCENT] = "%",
+  [anon_sym_AMP] = "&",
+  [anon_sym_PIPE] = "|",
+  [aux_sym_format_directive_type_token1] = "format_directive_type_token1",
+  [aux_sym_format_directive_type_token2] = "format_directive_type_token2",
+  [anon_sym_LF] = "\n",
+  [anon_sym_CR] = "\r",
+  [aux_sym_format_directive_type_token3] = "format_directive_type_token3",
+  [aux_sym_format_directive_type_token4] = "format_directive_type_token4",
+  [aux_sym_format_directive_type_token5] = "format_directive_type_token5",
+  [aux_sym_format_directive_type_token6] = "format_directive_type_token6",
+  [anon_sym__] = "_",
+  [aux_sym_format_directive_type_token7] = "format_directive_type_token7",
+  [aux_sym_format_directive_type_token8] = "format_directive_type_token8",
+  [aux_sym_format_directive_type_token9] = "format_directive_type_token9",
+  [aux_sym_format_directive_type_token10] = "format_directive_type_token10",
+  [anon_sym_SEMI] = ";",
+  [anon_sym_STAR] = "*",
+  [anon_sym_QMARK] = "\?",
+  [anon_sym_Newline] = "Newline",
+  [aux_sym_format_directive_type_token11] = "format_directive_type_token11",
+  [anon_sym_DQUOTE] = "\"",
+  [aux_sym_str_lit_token1] = "str_lit_token1",
+  [aux_sym_str_lit_token2] = "str_lit_token2",
   [sym_char_lit] = "char_lit",
   [sym_null_lit] = "null_lit",
   [sym_bool_lit] = "bool_lit",
@@ -80,16 +141,20 @@ static const char * const ts_symbol_names[] = {
   [aux_sym__sym_unqualified_token1] = "sym_name",
   [anon_sym_LPAREN] = "(",
   [anon_sym_RPAREN] = ")",
-  [anon_sym_SQUOTE] = "'",
   [anon_sym_BQUOTE] = "`",
   [anon_sym_COMMA_AT] = ",@",
-  [anon_sym_COMMA] = ",",
   [sym_source] = "source",
   [sym__gap] = "_gap",
-  [sym_comment_multiline] = "comment_multiline",
   [sym__form] = "_form",
+  [sym_num_lit] = "num_lit",
   [sym_kwd_lit] = "kwd_lit",
   [sym__kwd_marker] = "_kwd_marker",
+  [sym__format_token] = "_format_token",
+  [sym_format_prefix_parameters] = "format_prefix_parameters",
+  [sym_format_modifiers] = "format_modifiers",
+  [sym_format_directive_type] = "format_directive_type",
+  [sym_format_specifier] = "format_specifier",
+  [sym_str_lit] = "str_lit",
   [sym_sym_lit] = "sym_lit",
   [sym_list_lit] = "list_lit",
   [sym__bare_list_lit] = "_bare_list_lit",
@@ -98,7 +163,8 @@ static const char * const ts_symbol_names[] = {
   [sym_unquote_splicing_lit] = "unquote_splicing_lit",
   [sym_unquoting_lit] = "unquoting_lit",
   [aux_sym_source_repeat1] = "source_repeat1",
-  [aux_sym_comment_multiline_repeat1] = "comment_multiline_repeat1",
+  [aux_sym_format_modifiers_repeat1] = "format_modifiers_repeat1",
+  [aux_sym_str_lit_repeat1] = "str_lit_repeat1",
   [aux_sym__bare_list_lit_repeat1] = "_bare_list_lit_repeat1",
   [aux_sym_quoting_lit_repeat1] = "quoting_lit_repeat1",
 };
@@ -107,16 +173,44 @@ static const TSSymbol ts_symbol_map[] = {
   [ts_builtin_sym_end] = ts_builtin_sym_end,
   [sym__ws] = sym__ws,
   [sym_comment] = sym_comment,
-  [anon_sym_POUND_PIPE] = anon_sym_POUND_PIPE,
-  [aux_sym_comment_multiline_token1] = aux_sym_comment_multiline_token1,
-  [aux_sym_comment_multiline_token2] = aux_sym_comment_multiline_token2,
-  [aux_sym_comment_multiline_token3] = aux_sym_comment_multiline_token3,
-  [aux_sym_comment_multiline_token4] = aux_sym_comment_multiline_token4,
-  [anon_sym_PIPE_POUND] = anon_sym_PIPE_POUND,
-  [sym_num_lit] = sym_num_lit,
+  [sym_block_comment] = sym_block_comment,
+  [aux_sym_num_lit_token1] = aux_sym_num_lit_token1,
   [aux_sym__kwd_unqualified_token1] = aux_sym__kwd_unqualified_token1,
   [anon_sym_COLON] = anon_sym_COLON,
-  [sym_str_lit] = sym_str_lit,
+  [anon_sym_SQUOTE] = anon_sym_SQUOTE,
+  [aux_sym__format_token_token1] = sym_char_lit,
+  [anon_sym_v] = anon_sym_v,
+  [anon_sym_V] = anon_sym_V,
+  [anon_sym_POUND] = anon_sym_POUND,
+  [anon_sym_COMMA] = anon_sym_COMMA,
+  [anon_sym_AT] = anon_sym_AT,
+  [anon_sym_AT_COLON] = anon_sym_AT_COLON,
+  [anon_sym_COLON_AT] = anon_sym_COLON_AT,
+  [anon_sym_TILDE] = anon_sym_TILDE,
+  [anon_sym_PERCENT] = anon_sym_PERCENT,
+  [anon_sym_AMP] = anon_sym_AMP,
+  [anon_sym_PIPE] = anon_sym_PIPE,
+  [aux_sym_format_directive_type_token1] = aux_sym_format_directive_type_token1,
+  [aux_sym_format_directive_type_token2] = aux_sym_format_directive_type_token2,
+  [anon_sym_LF] = anon_sym_LF,
+  [anon_sym_CR] = anon_sym_CR,
+  [aux_sym_format_directive_type_token3] = aux_sym_format_directive_type_token3,
+  [aux_sym_format_directive_type_token4] = aux_sym_format_directive_type_token4,
+  [aux_sym_format_directive_type_token5] = aux_sym_format_directive_type_token5,
+  [aux_sym_format_directive_type_token6] = aux_sym_format_directive_type_token6,
+  [anon_sym__] = anon_sym__,
+  [aux_sym_format_directive_type_token7] = aux_sym_format_directive_type_token7,
+  [aux_sym_format_directive_type_token8] = aux_sym_format_directive_type_token8,
+  [aux_sym_format_directive_type_token9] = aux_sym_format_directive_type_token9,
+  [aux_sym_format_directive_type_token10] = aux_sym_format_directive_type_token10,
+  [anon_sym_SEMI] = anon_sym_SEMI,
+  [anon_sym_STAR] = anon_sym_STAR,
+  [anon_sym_QMARK] = anon_sym_QMARK,
+  [anon_sym_Newline] = anon_sym_Newline,
+  [aux_sym_format_directive_type_token11] = aux_sym_format_directive_type_token11,
+  [anon_sym_DQUOTE] = anon_sym_DQUOTE,
+  [aux_sym_str_lit_token1] = aux_sym_str_lit_token1,
+  [aux_sym_str_lit_token2] = aux_sym_str_lit_token2,
   [sym_char_lit] = sym_char_lit,
   [sym_null_lit] = sym_null_lit,
   [sym_bool_lit] = sym_bool_lit,
@@ -124,16 +218,20 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym__sym_unqualified_token1] = anon_sym_SLASH,
   [anon_sym_LPAREN] = anon_sym_LPAREN,
   [anon_sym_RPAREN] = anon_sym_RPAREN,
-  [anon_sym_SQUOTE] = anon_sym_SQUOTE,
   [anon_sym_BQUOTE] = anon_sym_BQUOTE,
   [anon_sym_COMMA_AT] = anon_sym_COMMA_AT,
-  [anon_sym_COMMA] = anon_sym_COMMA,
   [sym_source] = sym_source,
   [sym__gap] = sym__gap,
-  [sym_comment_multiline] = sym_comment_multiline,
   [sym__form] = sym__form,
+  [sym_num_lit] = sym_num_lit,
   [sym_kwd_lit] = sym_kwd_lit,
   [sym__kwd_marker] = sym__kwd_marker,
+  [sym__format_token] = sym__format_token,
+  [sym_format_prefix_parameters] = sym_format_prefix_parameters,
+  [sym_format_modifiers] = sym_format_modifiers,
+  [sym_format_directive_type] = sym_format_directive_type,
+  [sym_format_specifier] = sym_format_specifier,
+  [sym_str_lit] = sym_str_lit,
   [sym_sym_lit] = sym_sym_lit,
   [sym_list_lit] = sym_list_lit,
   [sym__bare_list_lit] = sym__bare_list_lit,
@@ -142,7 +240,8 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_unquote_splicing_lit] = sym_unquote_splicing_lit,
   [sym_unquoting_lit] = sym_unquoting_lit,
   [aux_sym_source_repeat1] = aux_sym_source_repeat1,
-  [aux_sym_comment_multiline_repeat1] = aux_sym_comment_multiline_repeat1,
+  [aux_sym_format_modifiers_repeat1] = aux_sym_format_modifiers_repeat1,
+  [aux_sym_str_lit_repeat1] = aux_sym_str_lit_repeat1,
   [aux_sym__bare_list_lit_repeat1] = aux_sym__bare_list_lit_repeat1,
   [aux_sym_quoting_lit_repeat1] = aux_sym_quoting_lit_repeat1,
 };
@@ -160,33 +259,13 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
-  [anon_sym_POUND_PIPE] = {
-    .visible = true,
-    .named = false,
-  },
-  [aux_sym_comment_multiline_token1] = {
-    .visible = false,
-    .named = false,
-  },
-  [aux_sym_comment_multiline_token2] = {
-    .visible = false,
-    .named = false,
-  },
-  [aux_sym_comment_multiline_token3] = {
-    .visible = false,
-    .named = false,
-  },
-  [aux_sym_comment_multiline_token4] = {
-    .visible = false,
-    .named = false,
-  },
-  [anon_sym_PIPE_POUND] = {
-    .visible = true,
-    .named = false,
-  },
-  [sym_num_lit] = {
+  [sym_block_comment] = {
     .visible = true,
     .named = true,
+  },
+  [aux_sym_num_lit_token1] = {
+    .visible = false,
+    .named = false,
   },
   [aux_sym__kwd_unqualified_token1] = {
     .visible = true,
@@ -196,9 +275,141 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
-  [sym_str_lit] = {
+  [anon_sym_SQUOTE] = {
+    .visible = true,
+    .named = false,
+  },
+  [aux_sym__format_token_token1] = {
     .visible = true,
     .named = true,
+  },
+  [anon_sym_v] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_V] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_POUND] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_COMMA] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_AT] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_AT_COLON] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_COLON_AT] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_TILDE] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_PERCENT] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_AMP] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_PIPE] = {
+    .visible = true,
+    .named = false,
+  },
+  [aux_sym_format_directive_type_token1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_format_directive_type_token2] = {
+    .visible = false,
+    .named = false,
+  },
+  [anon_sym_LF] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_CR] = {
+    .visible = true,
+    .named = false,
+  },
+  [aux_sym_format_directive_type_token3] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_format_directive_type_token4] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_format_directive_type_token5] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_format_directive_type_token6] = {
+    .visible = false,
+    .named = false,
+  },
+  [anon_sym__] = {
+    .visible = true,
+    .named = false,
+  },
+  [aux_sym_format_directive_type_token7] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_format_directive_type_token8] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_format_directive_type_token9] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_format_directive_type_token10] = {
+    .visible = false,
+    .named = false,
+  },
+  [anon_sym_SEMI] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_STAR] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_QMARK] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_Newline] = {
+    .visible = true,
+    .named = false,
+  },
+  [aux_sym_format_directive_type_token11] = {
+    .visible = false,
+    .named = false,
+  },
+  [anon_sym_DQUOTE] = {
+    .visible = true,
+    .named = false,
+  },
+  [aux_sym_str_lit_token1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_str_lit_token2] = {
+    .visible = false,
+    .named = false,
   },
   [sym_char_lit] = {
     .visible = true,
@@ -228,19 +439,11 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
-  [anon_sym_SQUOTE] = {
-    .visible = true,
-    .named = false,
-  },
   [anon_sym_BQUOTE] = {
     .visible = true,
     .named = false,
   },
   [anon_sym_COMMA_AT] = {
-    .visible = true,
-    .named = false,
-  },
-  [anon_sym_COMMA] = {
     .visible = true,
     .named = false,
   },
@@ -252,12 +455,12 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = true,
   },
-  [sym_comment_multiline] = {
-    .visible = true,
-    .named = true,
-  },
   [sym__form] = {
     .visible = false,
+    .named = true,
+  },
+  [sym_num_lit] = {
+    .visible = true,
     .named = true,
   },
   [sym_kwd_lit] = {
@@ -266,6 +469,30 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
   },
   [sym__kwd_marker] = {
     .visible = false,
+    .named = true,
+  },
+  [sym__format_token] = {
+    .visible = false,
+    .named = true,
+  },
+  [sym_format_prefix_parameters] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_format_modifiers] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_format_directive_type] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_format_specifier] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_str_lit] = {
+    .visible = true,
     .named = true,
   },
   [sym_sym_lit] = {
@@ -300,7 +527,11 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = false,
   },
-  [aux_sym_comment_multiline_repeat1] = {
+  [aux_sym_format_modifiers_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_str_lit_repeat1] = {
     .visible = false,
     .named = false,
   },
@@ -318,8 +549,10 @@ enum {
   field_close = 1,
   field_marker = 2,
   field_name = 3,
-  field_open = 4,
-  field_value = 5,
+  field_numberOfArgs = 4,
+  field_open = 5,
+  field_repetitions = 6,
+  field_value = 7,
 };
 
 static const char * const ts_field_names[] = {
@@ -327,7 +560,9 @@ static const char * const ts_field_names[] = {
   [field_close] = "close",
   [field_marker] = "marker",
   [field_name] = "name",
+  [field_numberOfArgs] = "numberOfArgs",
   [field_open] = "open",
+  [field_repetitions] = "repetitions",
   [field_value] = "value",
 };
 
@@ -335,12 +570,14 @@ static const TSFieldMapSlice ts_field_map_slices[PRODUCTION_ID_COUNT] = {
   [1] = {.index = 0, .length = 1},
   [2] = {.index = 1, .length = 3},
   [3] = {.index = 4, .length = 2},
-  [4] = {.index = 6, .length = 1},
-  [5] = {.index = 7, .length = 2},
+  [4] = {.index = 6, .length = 2},
+  [5] = {.index = 8, .length = 1},
   [6] = {.index = 9, .length = 2},
-  [7] = {.index = 11, .length = 3},
-  [8] = {.index = 14, .length = 2},
-  [9] = {.index = 16, .length = 2},
+  [7] = {.index = 11, .length = 2},
+  [9] = {.index = 13, .length = 3},
+  [10] = {.index = 16, .length = 2},
+  [11] = {.index = 18, .length = 1},
+  [12] = {.index = 19, .length = 1},
 };
 
 static const TSFieldMapEntry ts_field_map_entries[] = {
@@ -351,30 +588,37 @@ static const TSFieldMapEntry ts_field_map_entries[] = {
     {field_open, 0, .inherited = true},
     {field_value, 0, .inherited = true},
   [4] =
-    {field_close, 1},
-    {field_open, 0},
-  [6] =
-    {field_value, 0},
-  [7] =
     {field_marker, 0},
     {field_value, 1},
+  [6] =
+    {field_close, 1},
+    {field_open, 0},
+  [8] =
+    {field_value, 0},
   [9] =
     {field_marker, 0},
     {field_name, 1},
   [11] =
+    {field_marker, 0},
+    {field_value, 2},
+  [13] =
     {field_close, 2},
     {field_open, 0},
     {field_value, 1, .inherited = true},
-  [14] =
+  [16] =
     {field_value, 0, .inherited = true},
     {field_value, 1, .inherited = true},
-  [16] =
-    {field_marker, 0},
-    {field_value, 2},
+  [18] =
+    {field_repetitions, 0},
+  [19] =
+    {field_numberOfArgs, 0},
 };
 
 static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
   [0] = {0},
+  [8] = {
+    [0] = sym_num_lit,
+  },
 };
 
 static const uint16_t ts_non_terminal_alias_map[] = {
@@ -419,6 +663,31 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [34] = 34,
   [35] = 35,
   [36] = 36,
+  [37] = 37,
+  [38] = 38,
+  [39] = 39,
+  [40] = 40,
+  [41] = 41,
+  [42] = 42,
+  [43] = 43,
+  [44] = 44,
+  [45] = 45,
+  [46] = 46,
+  [47] = 47,
+  [48] = 48,
+  [49] = 49,
+  [50] = 50,
+  [51] = 51,
+  [52] = 52,
+  [53] = 53,
+  [54] = 54,
+  [55] = 55,
+  [56] = 56,
+  [57] = 57,
+  [58] = 58,
+  [59] = 59,
+  [60] = 60,
+  [61] = 61,
 };
 
 static inline bool aux_sym__kwd_unqualified_token1_character_set_1(int32_t c) {
@@ -471,6 +740,20 @@ static inline bool aux_sym__kwd_unqualified_token1_character_set_2(int32_t c) {
           ? (c >= 8200 && c <= 8202)
           : c <= 8233)
         : (c <= 8287 || c == 12288))))));
+}
+
+static inline bool aux_sym_str_lit_token1_character_set_1(int32_t c) {
+  return (c < 'X'
+    ? (c < 'O'
+      ? (c < 'B'
+        ? c == '$'
+        : c <= 'G')
+      : (c <= 'O' || (c >= 'R' && c <= 'T')))
+    : (c <= 'X' || (c < 'r'
+      ? (c < 'o'
+        ? (c >= 'b' && c <= 'g')
+        : c <= 'o')
+      : (c <= 't' || c == 'x'))));
 }
 
 static inline bool aux_sym__sym_unqualified_token1_character_set_1(int32_t c) {
@@ -530,117 +813,178 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(18);
-      if (lookahead == '"') ADVANCE(1);
-      if (lookahead == '#') ADVANCE(6);
-      if (lookahead == '\'') ADVANCE(54);
-      if (lookahead == '(') ADVANCE(52);
-      if (lookahead == ')') ADVANCE(53);
-      if (lookahead == ',') ADVANCE(57);
-      if (lookahead == '/') ADVANCE(43);
-      if (lookahead == ':') ADVANCE(36);
-      if (lookahead == ';') ADVANCE(22);
-      if (lookahead == '`') ADVANCE(55);
-      if (lookahead == 'n') ADVANCE(10);
-      if (lookahead == '|') ADVANCE(2);
-      if (lookahead == '\n' ||
-          lookahead == '\r') ADVANCE(19);
-      if (('+' <= lookahead && lookahead <= '-')) ADVANCE(4);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(31);
-      if (('\t' <= lookahead && lookahead <= '\f') ||
-          (28 <= lookahead && lookahead <= ' ') ||
-          lookahead == 5760 ||
-          (8192 <= lookahead && lookahead <= 8198) ||
-          (8200 <= lookahead && lookahead <= 8202) ||
-          lookahead == 8232 ||
-          lookahead == 8233 ||
-          lookahead == 8287 ||
-          lookahead == 12288) ADVANCE(20);
+      if (eof) ADVANCE(21);
+      if (lookahead == '\n') ADVANCE(66);
+      if (lookahead == '\r') ADVANCE(66);
+      if (lookahead == '"') ADVANCE(65);
+      if (lookahead == '#') ADVANCE(66);
+      if (lookahead == '%') ADVANCE(66);
+      if (lookahead == '&') ADVANCE(66);
+      if (lookahead == '\'') ADVANCE(66);
+      if (lookahead == '(') ADVANCE(66);
+      if (lookahead == ')') ADVANCE(66);
+      if (lookahead == '*') ADVANCE(66);
+      if (lookahead == ',') ADVANCE(66);
+      if (lookahead == '/') ADVANCE(66);
+      if (lookahead == ':') ADVANCE(66);
+      if (lookahead == ';') ADVANCE(66);
+      if (lookahead == '?') ADVANCE(66);
+      if (lookahead == '@') ADVANCE(66);
+      if (lookahead == 'V') ADVANCE(66);
+      if (lookahead == '\\') ADVANCE(34);
+      if (lookahead == '^') ADVANCE(66);
+      if (lookahead == '_') ADVANCE(66);
+      if (lookahead == '`') ADVANCE(66);
+      if (lookahead == 'v') ADVANCE(66);
+      if (lookahead == '|') ADVANCE(66);
+      if (lookahead == '~') ADVANCE(43);
+      if (lookahead == '<' ||
+          lookahead == '>') ADVANCE(66);
+      if (lookahead == 'A' ||
+          lookahead == 'a') ADVANCE(66);
+      if (lookahead == 'C' ||
+          lookahead == 'c') ADVANCE(66);
+      if (lookahead == 'I' ||
+          lookahead == 'i') ADVANCE(66);
+      if (lookahead == 'P' ||
+          lookahead == 'p') ADVANCE(66);
+      if (lookahead == 'W' ||
+          lookahead == 'w') ADVANCE(66);
+      if (('[' <= lookahead && lookahead <= ']')) ADVANCE(66);
+      if (('{' <= lookahead && lookahead <= '}')) ADVANCE(66);
+      if (aux_sym_str_lit_token1_character_set_1(lookahead)) ADVANCE(66);
+      if (lookahead != 0) ADVANCE(66);
       END_STATE();
     case 1:
-      if (lookahead == '"') ADVANCE(37);
-      if (lookahead == '\\') ADVANCE(14);
-      if (lookahead != 0) ADVANCE(1);
+      if (lookahead == '\n') ADVANCE(49);
+      if (lookahead == '\r') ADVANCE(50);
+      if (lookahead == '"') ADVANCE(65);
+      if (lookahead == '#') ADVANCE(37);
+      if (lookahead == '%') ADVANCE(44);
+      if (lookahead == '&') ADVANCE(45);
+      if (lookahead == '\'') ADVANCE(33);
+      if (lookahead == '*') ADVANCE(61);
+      if (lookahead == ',') ADVANCE(38);
+      if (lookahead == ':') ADVANCE(32);
+      if (lookahead == ';') ADVANCE(60);
+      if (lookahead == '?') ADVANCE(62);
+      if (lookahead == '@') ADVANCE(40);
+      if (lookahead == 'N') ADVANCE(7);
+      if (lookahead == 'V') ADVANCE(36);
+      if (lookahead == '^') ADVANCE(48);
+      if (lookahead == '_') ADVANCE(55);
+      if (lookahead == 'v') ADVANCE(35);
+      if (lookahead == '|') ADVANCE(46);
+      if (lookahead == '~') ADVANCE(43);
+      if (('+' <= lookahead && lookahead <= '-')) ADVANCE(4);
+      if (lookahead == '<' ||
+          lookahead == '>') ADVANCE(59);
+      if (lookahead == 'A' ||
+          lookahead == 'a') ADVANCE(54);
+      if (lookahead == 'C' ||
+          lookahead == 'c') ADVANCE(47);
+      if (lookahead == 'I' ||
+          lookahead == 'i') ADVANCE(52);
+      if (lookahead == 'P' ||
+          lookahead == 'p') ADVANCE(51);
+      if (lookahead == 'W' ||
+          lookahead == 'w') ADVANCE(53);
+      if (lookahead == '[' ||
+          lookahead == ']') ADVANCE(58);
+      if (('{' <= lookahead && lookahead <= '}')) ADVANCE(57);
+      if (lookahead == '(' ||
+          lookahead == ')') ADVANCE(56);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(26);
+      if (aux_sym_str_lit_token1_character_set_1(lookahead)) ADVANCE(64);
       END_STATE();
     case 2:
-      if (lookahead == '#') ADVANCE(30);
+      if (lookahead == '"') ADVANCE(65);
+      if (lookahead == '\\') ADVANCE(18);
+      if (lookahead == '~') ADVANCE(43);
+      if (lookahead != 0) ADVANCE(66);
       END_STATE();
     case 3:
-      if (lookahead == '#') ADVANCE(30);
-      if (lookahead == '|') ADVANCE(29);
+      if (lookahead == '#') ADVANCE(25);
+      if (lookahead != 0) ADVANCE(13);
       END_STATE();
     case 4:
-      if (lookahead == '#') ADVANCE(7);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(31);
+      if (lookahead == '#') ADVANCE(6);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(26);
       END_STATE();
     case 5:
-      if (lookahead == '#') ADVANCE(16);
-      if (lookahead == '|') ADVANCE(3);
-      if (lookahead == '\n' ||
-          lookahead == '\r') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(25);
+      if (lookahead == '\\') ADVANCE(19);
+      if (lookahead == 'b') ADVANCE(14);
+      if (lookahead == 'f' ||
+          lookahead == 't') ADVANCE(71);
+      if (lookahead == 'x') ADVANCE(15);
+      if (lookahead == '|') ADVANCE(13);
       END_STATE();
     case 6:
-      if (lookahead == '\\') ADVANCE(15);
-      if (lookahead == 'b') ADVANCE(11);
-      if (lookahead == 'f' ||
-          lookahead == 't') ADVANCE(42);
-      if (lookahead == 'x') ADVANCE(12);
-      if (lookahead == '|') ADVANCE(23);
+      if (lookahead == 'b') ADVANCE(14);
+      if (lookahead == 'x') ADVANCE(15);
       END_STATE();
     case 7:
-      if (lookahead == 'b') ADVANCE(11);
-      if (lookahead == 'x') ADVANCE(12);
+      if (lookahead == 'e') ADVANCE(12);
       END_STATE();
     case 8:
-      if (lookahead == 'e') ADVANCE(40);
+      if (lookahead == 'e') ADVANCE(63);
       END_STATE();
     case 9:
-      if (lookahead == 'n') ADVANCE(8);
+      if (lookahead == 'i') ADVANCE(11);
       END_STATE();
     case 10:
-      if (lookahead == 'o') ADVANCE(9);
+      if (lookahead == 'l') ADVANCE(9);
       END_STATE();
     case 11:
-      if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(32);
+      if (lookahead == 'n') ADVANCE(8);
       END_STATE();
     case 12:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(34);
+      if (lookahead == 'w') ADVANCE(10);
       END_STATE();
     case 13:
-      if (!aux_sym__kwd_unqualified_token1_character_set_1(lookahead)) ADVANCE(35);
+      if (lookahead == '|') ADVANCE(3);
+      if (lookahead != 0) ADVANCE(13);
       END_STATE();
     case 14:
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(1);
+      if (lookahead == '0' ||
+          lookahead == '1') ADVANCE(27);
       END_STATE();
     case 15:
-      if (lookahead != 0 &&
-          lookahead != '\\') ADVANCE(38);
-      if (lookahead == '\\') ADVANCE(39);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(29);
       END_STATE();
     case 16:
-      if (lookahead != 0 &&
-          lookahead != '|') ADVANCE(28);
+      if (!aux_sym__kwd_unqualified_token1_character_set_1(lookahead)) ADVANCE(30);
       END_STATE();
     case 17:
-      if (eof) ADVANCE(18);
-      if (lookahead == '"') ADVANCE(1);
-      if (lookahead == '#') ADVANCE(6);
-      if (lookahead == '\'') ADVANCE(54);
-      if (lookahead == '(') ADVANCE(52);
-      if (lookahead == ')') ADVANCE(53);
-      if (lookahead == ',') ADVANCE(57);
-      if (lookahead == '/') ADVANCE(43);
-      if (lookahead == ':') ADVANCE(36);
-      if (lookahead == ';') ADVANCE(22);
-      if (lookahead == '`') ADVANCE(55);
-      if (lookahead == 'n') ADVANCE(48);
-      if (('+' <= lookahead && lookahead <= '-')) ADVANCE(44);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(31);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(34);
+      END_STATE();
+    case 18:
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(67);
+      END_STATE();
+    case 19:
+      if (lookahead != 0 &&
+          lookahead != '\\') ADVANCE(68);
+      if (lookahead == '\\') ADVANCE(69);
+      END_STATE();
+    case 20:
+      if (eof) ADVANCE(21);
+      if (lookahead == '"') ADVANCE(65);
+      if (lookahead == '#') ADVANCE(5);
+      if (lookahead == '\'') ADVANCE(33);
+      if (lookahead == '(') ADVANCE(81);
+      if (lookahead == ')') ADVANCE(82);
+      if (lookahead == ',') ADVANCE(39);
+      if (lookahead == '/') ADVANCE(72);
+      if (lookahead == ':') ADVANCE(31);
+      if (lookahead == ';') ADVANCE(24);
+      if (lookahead == '`') ADVANCE(83);
+      if (lookahead == 'n') ADVANCE(77);
+      if (('+' <= lookahead && lookahead <= '-')) ADVANCE(73);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(26);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           (28 <= lookahead && lookahead <= ' ') ||
           lookahead == 5760 ||
@@ -649,32 +993,18 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == 8232 ||
           lookahead == 8233 ||
           lookahead == 8287 ||
-          lookahead == 12288) ADVANCE(20);
+          lookahead == 12288) ADVANCE(22);
       if (lookahead != 0 &&
           lookahead != '@' &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '{' &&
           lookahead != '}' &&
-          lookahead != '~') ADVANCE(51);
+          lookahead != '~') ADVANCE(80);
       END_STATE();
-    case 18:
+    case 21:
       ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
-    case 19:
-      ACCEPT_TOKEN(sym__ws);
-      if (lookahead == '\n' ||
-          lookahead == '\r') ADVANCE(19);
-      if (('\t' <= lookahead && lookahead <= '\f') ||
-          (28 <= lookahead && lookahead <= ' ') ||
-          lookahead == 5760 ||
-          (8192 <= lookahead && lookahead <= 8198) ||
-          (8200 <= lookahead && lookahead <= 8202) ||
-          lookahead == 8232 ||
-          lookahead == 8233 ||
-          lookahead == 8287 ||
-          lookahead == 12288) ADVANCE(20);
-      END_STATE();
-    case 20:
+    case 22:
       ACCEPT_TOKEN(sym__ws);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           (28 <= lookahead && lookahead <= ' ') ||
@@ -684,170 +1014,237 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == 8232 ||
           lookahead == 8233 ||
           lookahead == 8287 ||
-          lookahead == 12288) ADVANCE(20);
-      END_STATE();
-    case 21:
-      ACCEPT_TOKEN(sym_comment);
-      END_STATE();
-    case 22:
-      ACCEPT_TOKEN(sym_comment);
-      if (lookahead == '\n') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(22);
+          lookahead == 12288) ADVANCE(22);
       END_STATE();
     case 23:
-      ACCEPT_TOKEN(anon_sym_POUND_PIPE);
+      ACCEPT_TOKEN(sym_comment);
       END_STATE();
     case 24:
-      ACCEPT_TOKEN(aux_sym_comment_multiline_token1);
-      if (lookahead == '|') ADVANCE(29);
-      if (lookahead == '\n' ||
-          lookahead == '\r') ADVANCE(26);
-      if (lookahead != 0 &&
-          lookahead != '#') ADVANCE(27);
+      ACCEPT_TOKEN(sym_comment);
+      if (lookahead == '\n') ADVANCE(23);
+      if (lookahead != 0) ADVANCE(24);
       END_STATE();
     case 25:
-      ACCEPT_TOKEN(aux_sym_comment_multiline_token1);
-      if (lookahead == '|') ADVANCE(29);
-      if (lookahead != 0 &&
-          lookahead != '#') ADVANCE(27);
+      ACCEPT_TOKEN(sym_block_comment);
       END_STATE();
     case 26:
-      ACCEPT_TOKEN(aux_sym_comment_multiline_token1);
-      if (lookahead == '\n' ||
-          lookahead == '\r') ADVANCE(26);
-      if (lookahead != 0 &&
-          lookahead != '#' &&
-          lookahead != '|') ADVANCE(27);
+      ACCEPT_TOKEN(aux_sym_num_lit_token1);
+      if (lookahead == '.') ADVANCE(28);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(26);
       END_STATE();
     case 27:
-      ACCEPT_TOKEN(aux_sym_comment_multiline_token1);
-      if (lookahead != 0 &&
-          lookahead != '#' &&
-          lookahead != '|') ADVANCE(27);
+      ACCEPT_TOKEN(aux_sym_num_lit_token1);
+      if (lookahead == '0' ||
+          lookahead == '1') ADVANCE(27);
       END_STATE();
     case 28:
-      ACCEPT_TOKEN(aux_sym_comment_multiline_token2);
+      ACCEPT_TOKEN(aux_sym_num_lit_token1);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(28);
       END_STATE();
     case 29:
-      ACCEPT_TOKEN(aux_sym_comment_multiline_token3);
-      END_STATE();
-    case 30:
-      ACCEPT_TOKEN(anon_sym_PIPE_POUND);
-      END_STATE();
-    case 31:
-      ACCEPT_TOKEN(sym_num_lit);
-      if (lookahead == '.') ADVANCE(33);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(31);
-      END_STATE();
-    case 32:
-      ACCEPT_TOKEN(sym_num_lit);
-      if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(32);
-      END_STATE();
-    case 33:
-      ACCEPT_TOKEN(sym_num_lit);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(33);
-      END_STATE();
-    case 34:
-      ACCEPT_TOKEN(sym_num_lit);
+      ACCEPT_TOKEN(aux_sym_num_lit_token1);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(34);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(29);
       END_STATE();
-    case 35:
+    case 30:
       ACCEPT_TOKEN(aux_sym__kwd_unqualified_token1);
-      if (!aux_sym__kwd_unqualified_token1_character_set_2(lookahead)) ADVANCE(35);
+      if (!aux_sym__kwd_unqualified_token1_character_set_2(lookahead)) ADVANCE(30);
       END_STATE();
-    case 36:
+    case 31:
       ACCEPT_TOKEN(anon_sym_COLON);
       END_STATE();
+    case 32:
+      ACCEPT_TOKEN(anon_sym_COLON);
+      if (lookahead == '@') ADVANCE(42);
+      END_STATE();
+    case 33:
+      ACCEPT_TOKEN(anon_sym_SQUOTE);
+      END_STATE();
+    case 34:
+      ACCEPT_TOKEN(aux_sym__format_token_token1);
+      END_STATE();
+    case 35:
+      ACCEPT_TOKEN(anon_sym_v);
+      END_STATE();
+    case 36:
+      ACCEPT_TOKEN(anon_sym_V);
+      END_STATE();
     case 37:
-      ACCEPT_TOKEN(sym_str_lit);
+      ACCEPT_TOKEN(anon_sym_POUND);
+      if (lookahead == 'b') ADVANCE(14);
+      if (lookahead == 'x') ADVANCE(15);
       END_STATE();
     case 38:
-      ACCEPT_TOKEN(sym_char_lit);
+      ACCEPT_TOKEN(anon_sym_COMMA);
       END_STATE();
     case 39:
+      ACCEPT_TOKEN(anon_sym_COMMA);
+      if (lookahead == '@') ADVANCE(84);
+      END_STATE();
+    case 40:
+      ACCEPT_TOKEN(anon_sym_AT);
+      if (lookahead == ':') ADVANCE(41);
+      END_STATE();
+    case 41:
+      ACCEPT_TOKEN(anon_sym_AT_COLON);
+      END_STATE();
+    case 42:
+      ACCEPT_TOKEN(anon_sym_COLON_AT);
+      END_STATE();
+    case 43:
+      ACCEPT_TOKEN(anon_sym_TILDE);
+      END_STATE();
+    case 44:
+      ACCEPT_TOKEN(anon_sym_PERCENT);
+      END_STATE();
+    case 45:
+      ACCEPT_TOKEN(anon_sym_AMP);
+      END_STATE();
+    case 46:
+      ACCEPT_TOKEN(anon_sym_PIPE);
+      END_STATE();
+    case 47:
+      ACCEPT_TOKEN(aux_sym_format_directive_type_token1);
+      END_STATE();
+    case 48:
+      ACCEPT_TOKEN(aux_sym_format_directive_type_token2);
+      END_STATE();
+    case 49:
+      ACCEPT_TOKEN(anon_sym_LF);
+      END_STATE();
+    case 50:
+      ACCEPT_TOKEN(anon_sym_CR);
+      END_STATE();
+    case 51:
+      ACCEPT_TOKEN(aux_sym_format_directive_type_token3);
+      END_STATE();
+    case 52:
+      ACCEPT_TOKEN(aux_sym_format_directive_type_token4);
+      END_STATE();
+    case 53:
+      ACCEPT_TOKEN(aux_sym_format_directive_type_token5);
+      END_STATE();
+    case 54:
+      ACCEPT_TOKEN(aux_sym_format_directive_type_token6);
+      END_STATE();
+    case 55:
+      ACCEPT_TOKEN(anon_sym__);
+      END_STATE();
+    case 56:
+      ACCEPT_TOKEN(aux_sym_format_directive_type_token7);
+      END_STATE();
+    case 57:
+      ACCEPT_TOKEN(aux_sym_format_directive_type_token8);
+      END_STATE();
+    case 58:
+      ACCEPT_TOKEN(aux_sym_format_directive_type_token9);
+      END_STATE();
+    case 59:
+      ACCEPT_TOKEN(aux_sym_format_directive_type_token10);
+      END_STATE();
+    case 60:
+      ACCEPT_TOKEN(anon_sym_SEMI);
+      END_STATE();
+    case 61:
+      ACCEPT_TOKEN(anon_sym_STAR);
+      END_STATE();
+    case 62:
+      ACCEPT_TOKEN(anon_sym_QMARK);
+      END_STATE();
+    case 63:
+      ACCEPT_TOKEN(anon_sym_Newline);
+      END_STATE();
+    case 64:
+      ACCEPT_TOKEN(aux_sym_format_directive_type_token11);
+      END_STATE();
+    case 65:
+      ACCEPT_TOKEN(anon_sym_DQUOTE);
+      END_STATE();
+    case 66:
+      ACCEPT_TOKEN(aux_sym_str_lit_token1);
+      if (lookahead != 0 &&
+          lookahead != '"' &&
+          lookahead != '\\' &&
+          lookahead != '~') ADVANCE(66);
+      END_STATE();
+    case 67:
+      ACCEPT_TOKEN(aux_sym_str_lit_token2);
+      END_STATE();
+    case 68:
+      ACCEPT_TOKEN(sym_char_lit);
+      END_STATE();
+    case 69:
       ACCEPT_TOKEN(sym_char_lit);
       if (lookahead == 'n' ||
           lookahead == 's' ||
-          lookahead == 't') ADVANCE(38);
+          lookahead == 't') ADVANCE(68);
       END_STATE();
-    case 40:
+    case 70:
       ACCEPT_TOKEN(sym_null_lit);
+      if (!aux_sym__kwd_unqualified_token1_character_set_2(lookahead)) ADVANCE(80);
       END_STATE();
-    case 41:
-      ACCEPT_TOKEN(sym_null_lit);
-      if (!aux_sym__kwd_unqualified_token1_character_set_2(lookahead)) ADVANCE(51);
-      END_STATE();
-    case 42:
+    case 71:
       ACCEPT_TOKEN(sym_bool_lit);
       END_STATE();
-    case 43:
+    case 72:
       ACCEPT_TOKEN(anon_sym_SLASH);
       END_STATE();
-    case 44:
+    case 73:
       ACCEPT_TOKEN(aux_sym__sym_unqualified_token1);
-      if (lookahead == '#') ADVANCE(45);
-      if (!aux_sym__sym_unqualified_token1_character_set_1(lookahead)) ADVANCE(51);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(31);
+      if (lookahead == '#') ADVANCE(74);
+      if (!aux_sym__sym_unqualified_token1_character_set_1(lookahead)) ADVANCE(80);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(26);
       END_STATE();
-    case 45:
+    case 74:
       ACCEPT_TOKEN(aux_sym__sym_unqualified_token1);
-      if (lookahead == 'b') ADVANCE(49);
-      if (lookahead == 'x') ADVANCE(50);
-      if (!aux_sym__kwd_unqualified_token1_character_set_2(lookahead)) ADVANCE(51);
+      if (lookahead == 'b') ADVANCE(78);
+      if (lookahead == 'x') ADVANCE(79);
+      if (!aux_sym__kwd_unqualified_token1_character_set_2(lookahead)) ADVANCE(80);
       END_STATE();
-    case 46:
+    case 75:
       ACCEPT_TOKEN(aux_sym__sym_unqualified_token1);
-      if (lookahead == 'e') ADVANCE(41);
-      if (!aux_sym__kwd_unqualified_token1_character_set_2(lookahead)) ADVANCE(51);
+      if (lookahead == 'e') ADVANCE(70);
+      if (!aux_sym__kwd_unqualified_token1_character_set_2(lookahead)) ADVANCE(80);
       END_STATE();
-    case 47:
+    case 76:
       ACCEPT_TOKEN(aux_sym__sym_unqualified_token1);
-      if (lookahead == 'n') ADVANCE(46);
-      if (!aux_sym__kwd_unqualified_token1_character_set_2(lookahead)) ADVANCE(51);
+      if (lookahead == 'n') ADVANCE(75);
+      if (!aux_sym__kwd_unqualified_token1_character_set_2(lookahead)) ADVANCE(80);
       END_STATE();
-    case 48:
+    case 77:
       ACCEPT_TOKEN(aux_sym__sym_unqualified_token1);
-      if (lookahead == 'o') ADVANCE(47);
-      if (!aux_sym__kwd_unqualified_token1_character_set_2(lookahead)) ADVANCE(51);
+      if (lookahead == 'o') ADVANCE(76);
+      if (!aux_sym__kwd_unqualified_token1_character_set_2(lookahead)) ADVANCE(80);
       END_STATE();
-    case 49:
+    case 78:
       ACCEPT_TOKEN(aux_sym__sym_unqualified_token1);
       if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(32);
-      if (!aux_sym__kwd_unqualified_token1_character_set_2(lookahead)) ADVANCE(51);
+          lookahead == '1') ADVANCE(27);
+      if (!aux_sym__kwd_unqualified_token1_character_set_2(lookahead)) ADVANCE(80);
       END_STATE();
-    case 50:
+    case 79:
       ACCEPT_TOKEN(aux_sym__sym_unqualified_token1);
-      if (!aux_sym__sym_unqualified_token1_character_set_2(lookahead)) ADVANCE(51);
+      if (!aux_sym__sym_unqualified_token1_character_set_2(lookahead)) ADVANCE(80);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(34);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(29);
       END_STATE();
-    case 51:
+    case 80:
       ACCEPT_TOKEN(aux_sym__sym_unqualified_token1);
-      if (!aux_sym__kwd_unqualified_token1_character_set_2(lookahead)) ADVANCE(51);
+      if (!aux_sym__kwd_unqualified_token1_character_set_2(lookahead)) ADVANCE(80);
       END_STATE();
-    case 52:
+    case 81:
       ACCEPT_TOKEN(anon_sym_LPAREN);
       END_STATE();
-    case 53:
+    case 82:
       ACCEPT_TOKEN(anon_sym_RPAREN);
       END_STATE();
-    case 54:
-      ACCEPT_TOKEN(anon_sym_SQUOTE);
-      END_STATE();
-    case 55:
+    case 83:
       ACCEPT_TOKEN(anon_sym_BQUOTE);
       END_STATE();
-    case 56:
+    case 84:
       ACCEPT_TOKEN(anon_sym_COMMA_AT);
-      END_STATE();
-    case 57:
-      ACCEPT_TOKEN(anon_sym_COMMA);
-      if (lookahead == '@') ADVANCE(56);
       END_STATE();
     default:
       return false;
@@ -856,1053 +1253,1934 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 17},
-  [2] = {.lex_state = 17},
-  [3] = {.lex_state = 17},
-  [4] = {.lex_state = 17},
-  [5] = {.lex_state = 17},
-  [6] = {.lex_state = 17},
-  [7] = {.lex_state = 17},
-  [8] = {.lex_state = 17},
-  [9] = {.lex_state = 17},
-  [10] = {.lex_state = 17},
-  [11] = {.lex_state = 17},
-  [12] = {.lex_state = 17},
-  [13] = {.lex_state = 17},
-  [14] = {.lex_state = 17},
-  [15] = {.lex_state = 17},
-  [16] = {.lex_state = 17},
-  [17] = {.lex_state = 17},
-  [18] = {.lex_state = 17},
-  [19] = {.lex_state = 17},
-  [20] = {.lex_state = 17},
-  [21] = {.lex_state = 17},
-  [22] = {.lex_state = 17},
-  [23] = {.lex_state = 17},
-  [24] = {.lex_state = 17},
-  [25] = {.lex_state = 17},
-  [26] = {.lex_state = 17},
-  [27] = {.lex_state = 17},
-  [28] = {.lex_state = 17},
-  [29] = {.lex_state = 17},
-  [30] = {.lex_state = 17},
-  [31] = {.lex_state = 17},
-  [32] = {.lex_state = 5},
-  [33] = {.lex_state = 5},
-  [34] = {.lex_state = 5},
-  [35] = {.lex_state = 13},
-  [36] = {.lex_state = 0},
+  [1] = {.lex_state = 20},
+  [2] = {.lex_state = 1},
+  [3] = {.lex_state = 1},
+  [4] = {.lex_state = 1},
+  [5] = {.lex_state = 1},
+  [6] = {.lex_state = 20},
+  [7] = {.lex_state = 20},
+  [8] = {.lex_state = 20},
+  [9] = {.lex_state = 20},
+  [10] = {.lex_state = 20},
+  [11] = {.lex_state = 20},
+  [12] = {.lex_state = 20},
+  [13] = {.lex_state = 20},
+  [14] = {.lex_state = 20},
+  [15] = {.lex_state = 20},
+  [16] = {.lex_state = 20},
+  [17] = {.lex_state = 20},
+  [18] = {.lex_state = 20},
+  [19] = {.lex_state = 1},
+  [20] = {.lex_state = 1},
+  [21] = {.lex_state = 1},
+  [22] = {.lex_state = 1},
+  [23] = {.lex_state = 1},
+  [24] = {.lex_state = 20},
+  [25] = {.lex_state = 20},
+  [26] = {.lex_state = 20},
+  [27] = {.lex_state = 20},
+  [28] = {.lex_state = 20},
+  [29] = {.lex_state = 20},
+  [30] = {.lex_state = 20},
+  [31] = {.lex_state = 20},
+  [32] = {.lex_state = 20},
+  [33] = {.lex_state = 20},
+  [34] = {.lex_state = 20},
+  [35] = {.lex_state = 20},
+  [36] = {.lex_state = 20},
+  [37] = {.lex_state = 20},
+  [38] = {.lex_state = 20},
+  [39] = {.lex_state = 20},
+  [40] = {.lex_state = 20},
+  [41] = {.lex_state = 20},
+  [42] = {.lex_state = 20},
+  [43] = {.lex_state = 1},
+  [44] = {.lex_state = 1},
+  [45] = {.lex_state = 1},
+  [46] = {.lex_state = 1},
+  [47] = {.lex_state = 1},
+  [48] = {.lex_state = 2},
+  [49] = {.lex_state = 2},
+  [50] = {.lex_state = 1},
+  [51] = {.lex_state = 2},
+  [52] = {.lex_state = 2},
+  [53] = {.lex_state = 2},
+  [54] = {.lex_state = 2},
+  [55] = {.lex_state = 2},
+  [56] = {.lex_state = 2},
+  [57] = {.lex_state = 2},
+  [58] = {.lex_state = 2},
+  [59] = {.lex_state = 16},
+  [60] = {.lex_state = 17},
+  [61] = {.lex_state = 0},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
   [0] = {
     [ts_builtin_sym_end] = ACTIONS(1),
-    [sym__ws] = ACTIONS(1),
-    [sym_comment] = ACTIONS(1),
-    [anon_sym_POUND_PIPE] = ACTIONS(1),
-    [aux_sym_comment_multiline_token4] = ACTIONS(1),
-    [anon_sym_PIPE_POUND] = ACTIONS(1),
-    [sym_num_lit] = ACTIONS(1),
     [anon_sym_COLON] = ACTIONS(1),
-    [sym_str_lit] = ACTIONS(1),
+    [anon_sym_SQUOTE] = ACTIONS(1),
+    [aux_sym__format_token_token1] = ACTIONS(1),
+    [anon_sym_v] = ACTIONS(1),
+    [anon_sym_V] = ACTIONS(1),
+    [anon_sym_POUND] = ACTIONS(1),
+    [anon_sym_COMMA] = ACTIONS(1),
+    [anon_sym_AT] = ACTIONS(1),
+    [anon_sym_TILDE] = ACTIONS(1),
+    [anon_sym_PERCENT] = ACTIONS(1),
+    [anon_sym_AMP] = ACTIONS(1),
+    [anon_sym_PIPE] = ACTIONS(1),
+    [aux_sym_format_directive_type_token1] = ACTIONS(1),
+    [aux_sym_format_directive_type_token2] = ACTIONS(1),
+    [anon_sym_LF] = ACTIONS(1),
+    [anon_sym_CR] = ACTIONS(1),
+    [aux_sym_format_directive_type_token3] = ACTIONS(1),
+    [aux_sym_format_directive_type_token4] = ACTIONS(1),
+    [aux_sym_format_directive_type_token5] = ACTIONS(1),
+    [aux_sym_format_directive_type_token6] = ACTIONS(1),
+    [anon_sym__] = ACTIONS(1),
+    [aux_sym_format_directive_type_token7] = ACTIONS(1),
+    [aux_sym_format_directive_type_token8] = ACTIONS(1),
+    [aux_sym_format_directive_type_token9] = ACTIONS(1),
+    [aux_sym_format_directive_type_token10] = ACTIONS(1),
+    [anon_sym_SEMI] = ACTIONS(1),
+    [anon_sym_STAR] = ACTIONS(1),
+    [anon_sym_QMARK] = ACTIONS(1),
+    [aux_sym_format_directive_type_token11] = ACTIONS(1),
+    [anon_sym_DQUOTE] = ACTIONS(1),
+    [aux_sym_str_lit_token1] = ACTIONS(1),
     [sym_char_lit] = ACTIONS(1),
-    [sym_null_lit] = ACTIONS(1),
-    [sym_bool_lit] = ACTIONS(1),
     [anon_sym_SLASH] = ACTIONS(1),
     [anon_sym_LPAREN] = ACTIONS(1),
     [anon_sym_RPAREN] = ACTIONS(1),
-    [anon_sym_SQUOTE] = ACTIONS(1),
     [anon_sym_BQUOTE] = ACTIONS(1),
-    [anon_sym_COMMA_AT] = ACTIONS(1),
-    [anon_sym_COMMA] = ACTIONS(1),
   },
   [1] = {
-    [sym_source] = STATE(36),
-    [sym__gap] = STATE(6),
-    [sym_comment_multiline] = STATE(6),
-    [sym__form] = STATE(6),
-    [sym_kwd_lit] = STATE(6),
-    [sym__kwd_marker] = STATE(35),
-    [sym_sym_lit] = STATE(6),
-    [sym_list_lit] = STATE(6),
-    [sym__bare_list_lit] = STATE(22),
-    [sym_quoting_lit] = STATE(6),
-    [sym_quasi_quoting_lit] = STATE(6),
-    [sym_unquote_splicing_lit] = STATE(6),
-    [sym_unquoting_lit] = STATE(6),
-    [aux_sym_source_repeat1] = STATE(6),
+    [sym_source] = STATE(61),
+    [sym__gap] = STATE(10),
+    [sym__form] = STATE(10),
+    [sym_num_lit] = STATE(10),
+    [sym_kwd_lit] = STATE(10),
+    [sym__kwd_marker] = STATE(59),
+    [sym_str_lit] = STATE(10),
+    [sym_sym_lit] = STATE(10),
+    [sym_list_lit] = STATE(10),
+    [sym__bare_list_lit] = STATE(33),
+    [sym_quoting_lit] = STATE(10),
+    [sym_quasi_quoting_lit] = STATE(10),
+    [sym_unquote_splicing_lit] = STATE(10),
+    [sym_unquoting_lit] = STATE(10),
+    [aux_sym_source_repeat1] = STATE(10),
     [ts_builtin_sym_end] = ACTIONS(3),
     [sym__ws] = ACTIONS(5),
     [sym_comment] = ACTIONS(5),
-    [anon_sym_POUND_PIPE] = ACTIONS(7),
-    [sym_num_lit] = ACTIONS(5),
+    [sym_block_comment] = ACTIONS(5),
+    [aux_sym_num_lit_token1] = ACTIONS(7),
     [anon_sym_COLON] = ACTIONS(9),
-    [sym_str_lit] = ACTIONS(5),
+    [anon_sym_SQUOTE] = ACTIONS(11),
+    [anon_sym_COMMA] = ACTIONS(13),
+    [anon_sym_DQUOTE] = ACTIONS(15),
     [sym_char_lit] = ACTIONS(5),
-    [sym_null_lit] = ACTIONS(11),
+    [sym_null_lit] = ACTIONS(17),
     [sym_bool_lit] = ACTIONS(5),
-    [anon_sym_SLASH] = ACTIONS(13),
-    [aux_sym__sym_unqualified_token1] = ACTIONS(15),
-    [anon_sym_LPAREN] = ACTIONS(17),
-    [anon_sym_SQUOTE] = ACTIONS(19),
-    [anon_sym_BQUOTE] = ACTIONS(21),
-    [anon_sym_COMMA_AT] = ACTIONS(23),
-    [anon_sym_COMMA] = ACTIONS(25),
-  },
-  [2] = {
-    [sym__gap] = STATE(3),
-    [sym_comment_multiline] = STATE(3),
-    [sym__form] = STATE(31),
-    [sym_kwd_lit] = STATE(31),
-    [sym__kwd_marker] = STATE(35),
-    [sym_sym_lit] = STATE(31),
-    [sym_list_lit] = STATE(31),
-    [sym__bare_list_lit] = STATE(22),
-    [sym_quoting_lit] = STATE(31),
-    [sym_quasi_quoting_lit] = STATE(31),
-    [sym_unquote_splicing_lit] = STATE(31),
-    [sym_unquoting_lit] = STATE(31),
-    [aux_sym__bare_list_lit_repeat1] = STATE(3),
-    [sym__ws] = ACTIONS(27),
-    [sym_comment] = ACTIONS(27),
-    [anon_sym_POUND_PIPE] = ACTIONS(7),
-    [sym_num_lit] = ACTIONS(29),
-    [anon_sym_COLON] = ACTIONS(9),
-    [sym_str_lit] = ACTIONS(29),
-    [sym_char_lit] = ACTIONS(29),
-    [sym_null_lit] = ACTIONS(31),
-    [sym_bool_lit] = ACTIONS(29),
-    [anon_sym_SLASH] = ACTIONS(13),
-    [aux_sym__sym_unqualified_token1] = ACTIONS(15),
-    [anon_sym_LPAREN] = ACTIONS(17),
-    [anon_sym_RPAREN] = ACTIONS(33),
-    [anon_sym_SQUOTE] = ACTIONS(19),
-    [anon_sym_BQUOTE] = ACTIONS(21),
-    [anon_sym_COMMA_AT] = ACTIONS(23),
-    [anon_sym_COMMA] = ACTIONS(25),
-  },
-  [3] = {
-    [sym__gap] = STATE(3),
-    [sym_comment_multiline] = STATE(3),
-    [sym__form] = STATE(31),
-    [sym_kwd_lit] = STATE(31),
-    [sym__kwd_marker] = STATE(35),
-    [sym_sym_lit] = STATE(31),
-    [sym_list_lit] = STATE(31),
-    [sym__bare_list_lit] = STATE(22),
-    [sym_quoting_lit] = STATE(31),
-    [sym_quasi_quoting_lit] = STATE(31),
-    [sym_unquote_splicing_lit] = STATE(31),
-    [sym_unquoting_lit] = STATE(31),
-    [aux_sym__bare_list_lit_repeat1] = STATE(3),
-    [sym__ws] = ACTIONS(35),
-    [sym_comment] = ACTIONS(35),
-    [anon_sym_POUND_PIPE] = ACTIONS(38),
-    [sym_num_lit] = ACTIONS(41),
-    [anon_sym_COLON] = ACTIONS(44),
-    [sym_str_lit] = ACTIONS(41),
-    [sym_char_lit] = ACTIONS(41),
-    [sym_null_lit] = ACTIONS(47),
-    [sym_bool_lit] = ACTIONS(41),
-    [anon_sym_SLASH] = ACTIONS(50),
-    [aux_sym__sym_unqualified_token1] = ACTIONS(53),
-    [anon_sym_LPAREN] = ACTIONS(56),
-    [anon_sym_RPAREN] = ACTIONS(59),
-    [anon_sym_SQUOTE] = ACTIONS(61),
-    [anon_sym_BQUOTE] = ACTIONS(64),
-    [anon_sym_COMMA_AT] = ACTIONS(67),
-    [anon_sym_COMMA] = ACTIONS(70),
-  },
-  [4] = {
-    [sym__gap] = STATE(2),
-    [sym_comment_multiline] = STATE(2),
-    [sym__form] = STATE(31),
-    [sym_kwd_lit] = STATE(31),
-    [sym__kwd_marker] = STATE(35),
-    [sym_sym_lit] = STATE(31),
-    [sym_list_lit] = STATE(31),
-    [sym__bare_list_lit] = STATE(22),
-    [sym_quoting_lit] = STATE(31),
-    [sym_quasi_quoting_lit] = STATE(31),
-    [sym_unquote_splicing_lit] = STATE(31),
-    [sym_unquoting_lit] = STATE(31),
-    [aux_sym__bare_list_lit_repeat1] = STATE(2),
-    [sym__ws] = ACTIONS(73),
-    [sym_comment] = ACTIONS(73),
-    [anon_sym_POUND_PIPE] = ACTIONS(7),
-    [sym_num_lit] = ACTIONS(29),
-    [anon_sym_COLON] = ACTIONS(9),
-    [sym_str_lit] = ACTIONS(29),
-    [sym_char_lit] = ACTIONS(29),
-    [sym_null_lit] = ACTIONS(31),
-    [sym_bool_lit] = ACTIONS(29),
-    [anon_sym_SLASH] = ACTIONS(13),
-    [aux_sym__sym_unqualified_token1] = ACTIONS(15),
-    [anon_sym_LPAREN] = ACTIONS(17),
-    [anon_sym_RPAREN] = ACTIONS(75),
-    [anon_sym_SQUOTE] = ACTIONS(19),
-    [anon_sym_BQUOTE] = ACTIONS(21),
-    [anon_sym_COMMA_AT] = ACTIONS(23),
-    [anon_sym_COMMA] = ACTIONS(25),
-  },
-  [5] = {
-    [sym__gap] = STATE(5),
-    [sym_comment_multiline] = STATE(5),
-    [sym__form] = STATE(5),
-    [sym_kwd_lit] = STATE(5),
-    [sym__kwd_marker] = STATE(35),
-    [sym_sym_lit] = STATE(5),
-    [sym_list_lit] = STATE(5),
-    [sym__bare_list_lit] = STATE(22),
-    [sym_quoting_lit] = STATE(5),
-    [sym_quasi_quoting_lit] = STATE(5),
-    [sym_unquote_splicing_lit] = STATE(5),
-    [sym_unquoting_lit] = STATE(5),
-    [aux_sym_source_repeat1] = STATE(5),
-    [ts_builtin_sym_end] = ACTIONS(77),
-    [sym__ws] = ACTIONS(79),
-    [sym_comment] = ACTIONS(79),
-    [anon_sym_POUND_PIPE] = ACTIONS(82),
-    [sym_num_lit] = ACTIONS(79),
-    [anon_sym_COLON] = ACTIONS(85),
-    [sym_str_lit] = ACTIONS(79),
-    [sym_char_lit] = ACTIONS(79),
-    [sym_null_lit] = ACTIONS(88),
-    [sym_bool_lit] = ACTIONS(79),
-    [anon_sym_SLASH] = ACTIONS(91),
-    [aux_sym__sym_unqualified_token1] = ACTIONS(94),
-    [anon_sym_LPAREN] = ACTIONS(97),
-    [anon_sym_SQUOTE] = ACTIONS(100),
-    [anon_sym_BQUOTE] = ACTIONS(103),
-    [anon_sym_COMMA_AT] = ACTIONS(106),
-    [anon_sym_COMMA] = ACTIONS(109),
-  },
-  [6] = {
-    [sym__gap] = STATE(5),
-    [sym_comment_multiline] = STATE(5),
-    [sym__form] = STATE(5),
-    [sym_kwd_lit] = STATE(5),
-    [sym__kwd_marker] = STATE(35),
-    [sym_sym_lit] = STATE(5),
-    [sym_list_lit] = STATE(5),
-    [sym__bare_list_lit] = STATE(22),
-    [sym_quoting_lit] = STATE(5),
-    [sym_quasi_quoting_lit] = STATE(5),
-    [sym_unquote_splicing_lit] = STATE(5),
-    [sym_unquoting_lit] = STATE(5),
-    [aux_sym_source_repeat1] = STATE(5),
-    [ts_builtin_sym_end] = ACTIONS(112),
-    [sym__ws] = ACTIONS(114),
-    [sym_comment] = ACTIONS(114),
-    [anon_sym_POUND_PIPE] = ACTIONS(7),
-    [sym_num_lit] = ACTIONS(114),
-    [anon_sym_COLON] = ACTIONS(9),
-    [sym_str_lit] = ACTIONS(114),
-    [sym_char_lit] = ACTIONS(114),
-    [sym_null_lit] = ACTIONS(116),
-    [sym_bool_lit] = ACTIONS(114),
-    [anon_sym_SLASH] = ACTIONS(13),
-    [aux_sym__sym_unqualified_token1] = ACTIONS(15),
-    [anon_sym_LPAREN] = ACTIONS(17),
-    [anon_sym_SQUOTE] = ACTIONS(19),
-    [anon_sym_BQUOTE] = ACTIONS(21),
-    [anon_sym_COMMA_AT] = ACTIONS(23),
-    [anon_sym_COMMA] = ACTIONS(25),
-  },
-  [7] = {
-    [sym__gap] = STATE(14),
-    [sym_comment_multiline] = STATE(14),
-    [sym__form] = STATE(16),
-    [sym_kwd_lit] = STATE(16),
-    [sym__kwd_marker] = STATE(35),
-    [sym_sym_lit] = STATE(16),
-    [sym_list_lit] = STATE(16),
-    [sym__bare_list_lit] = STATE(22),
-    [sym_quoting_lit] = STATE(16),
-    [sym_quasi_quoting_lit] = STATE(16),
-    [sym_unquote_splicing_lit] = STATE(16),
-    [sym_unquoting_lit] = STATE(16),
-    [aux_sym_quoting_lit_repeat1] = STATE(14),
-    [sym__ws] = ACTIONS(118),
-    [sym_comment] = ACTIONS(118),
-    [anon_sym_POUND_PIPE] = ACTIONS(7),
-    [sym_num_lit] = ACTIONS(120),
-    [anon_sym_COLON] = ACTIONS(9),
-    [sym_str_lit] = ACTIONS(120),
-    [sym_char_lit] = ACTIONS(120),
-    [sym_null_lit] = ACTIONS(122),
-    [sym_bool_lit] = ACTIONS(120),
-    [anon_sym_SLASH] = ACTIONS(13),
-    [aux_sym__sym_unqualified_token1] = ACTIONS(15),
-    [anon_sym_LPAREN] = ACTIONS(17),
-    [anon_sym_SQUOTE] = ACTIONS(19),
-    [anon_sym_BQUOTE] = ACTIONS(21),
-    [anon_sym_COMMA_AT] = ACTIONS(23),
-    [anon_sym_COMMA] = ACTIONS(25),
-  },
-  [8] = {
-    [sym__gap] = STATE(13),
-    [sym_comment_multiline] = STATE(13),
-    [sym__form] = STATE(18),
-    [sym_kwd_lit] = STATE(18),
-    [sym__kwd_marker] = STATE(35),
-    [sym_sym_lit] = STATE(18),
-    [sym_list_lit] = STATE(18),
-    [sym__bare_list_lit] = STATE(22),
-    [sym_quoting_lit] = STATE(18),
-    [sym_quasi_quoting_lit] = STATE(18),
-    [sym_unquote_splicing_lit] = STATE(18),
-    [sym_unquoting_lit] = STATE(18),
-    [aux_sym_quoting_lit_repeat1] = STATE(13),
-    [sym__ws] = ACTIONS(124),
-    [sym_comment] = ACTIONS(124),
-    [anon_sym_POUND_PIPE] = ACTIONS(7),
-    [sym_num_lit] = ACTIONS(126),
-    [anon_sym_COLON] = ACTIONS(9),
-    [sym_str_lit] = ACTIONS(126),
-    [sym_char_lit] = ACTIONS(126),
-    [sym_null_lit] = ACTIONS(128),
-    [sym_bool_lit] = ACTIONS(126),
-    [anon_sym_SLASH] = ACTIONS(13),
-    [aux_sym__sym_unqualified_token1] = ACTIONS(15),
-    [anon_sym_LPAREN] = ACTIONS(17),
-    [anon_sym_SQUOTE] = ACTIONS(19),
-    [anon_sym_BQUOTE] = ACTIONS(21),
-    [anon_sym_COMMA_AT] = ACTIONS(23),
-    [anon_sym_COMMA] = ACTIONS(25),
-  },
-  [9] = {
-    [sym__gap] = STATE(12),
-    [sym_comment_multiline] = STATE(12),
-    [sym__form] = STATE(19),
-    [sym_kwd_lit] = STATE(19),
-    [sym__kwd_marker] = STATE(35),
-    [sym_sym_lit] = STATE(19),
-    [sym_list_lit] = STATE(19),
-    [sym__bare_list_lit] = STATE(22),
-    [sym_quoting_lit] = STATE(19),
-    [sym_quasi_quoting_lit] = STATE(19),
-    [sym_unquote_splicing_lit] = STATE(19),
-    [sym_unquoting_lit] = STATE(19),
-    [aux_sym_quoting_lit_repeat1] = STATE(12),
-    [sym__ws] = ACTIONS(130),
-    [sym_comment] = ACTIONS(130),
-    [anon_sym_POUND_PIPE] = ACTIONS(7),
-    [sym_num_lit] = ACTIONS(132),
-    [anon_sym_COLON] = ACTIONS(9),
-    [sym_str_lit] = ACTIONS(132),
-    [sym_char_lit] = ACTIONS(132),
-    [sym_null_lit] = ACTIONS(134),
-    [sym_bool_lit] = ACTIONS(132),
-    [anon_sym_SLASH] = ACTIONS(13),
-    [aux_sym__sym_unqualified_token1] = ACTIONS(15),
-    [anon_sym_LPAREN] = ACTIONS(17),
-    [anon_sym_SQUOTE] = ACTIONS(19),
-    [anon_sym_BQUOTE] = ACTIONS(21),
-    [anon_sym_COMMA_AT] = ACTIONS(23),
-    [anon_sym_COMMA] = ACTIONS(25),
-  },
-  [10] = {
-    [sym__gap] = STATE(11),
-    [sym_comment_multiline] = STATE(11),
-    [sym__form] = STATE(21),
-    [sym_kwd_lit] = STATE(21),
-    [sym__kwd_marker] = STATE(35),
-    [sym_sym_lit] = STATE(21),
-    [sym_list_lit] = STATE(21),
-    [sym__bare_list_lit] = STATE(22),
-    [sym_quoting_lit] = STATE(21),
-    [sym_quasi_quoting_lit] = STATE(21),
-    [sym_unquote_splicing_lit] = STATE(21),
-    [sym_unquoting_lit] = STATE(21),
-    [aux_sym_quoting_lit_repeat1] = STATE(11),
-    [sym__ws] = ACTIONS(136),
-    [sym_comment] = ACTIONS(136),
-    [anon_sym_POUND_PIPE] = ACTIONS(7),
-    [sym_num_lit] = ACTIONS(138),
-    [anon_sym_COLON] = ACTIONS(9),
-    [sym_str_lit] = ACTIONS(138),
-    [sym_char_lit] = ACTIONS(138),
-    [sym_null_lit] = ACTIONS(140),
-    [sym_bool_lit] = ACTIONS(138),
-    [anon_sym_SLASH] = ACTIONS(13),
-    [aux_sym__sym_unqualified_token1] = ACTIONS(15),
-    [anon_sym_LPAREN] = ACTIONS(17),
-    [anon_sym_SQUOTE] = ACTIONS(19),
-    [anon_sym_BQUOTE] = ACTIONS(21),
-    [anon_sym_COMMA_AT] = ACTIONS(23),
-    [anon_sym_COMMA] = ACTIONS(25),
-  },
-  [11] = {
-    [sym__gap] = STATE(15),
-    [sym_comment_multiline] = STATE(15),
-    [sym__form] = STATE(30),
-    [sym_kwd_lit] = STATE(30),
-    [sym__kwd_marker] = STATE(35),
-    [sym_sym_lit] = STATE(30),
-    [sym_list_lit] = STATE(30),
-    [sym__bare_list_lit] = STATE(22),
-    [sym_quoting_lit] = STATE(30),
-    [sym_quasi_quoting_lit] = STATE(30),
-    [sym_unquote_splicing_lit] = STATE(30),
-    [sym_unquoting_lit] = STATE(30),
-    [aux_sym_quoting_lit_repeat1] = STATE(15),
-    [sym__ws] = ACTIONS(142),
-    [sym_comment] = ACTIONS(142),
-    [anon_sym_POUND_PIPE] = ACTIONS(7),
-    [sym_num_lit] = ACTIONS(144),
-    [anon_sym_COLON] = ACTIONS(9),
-    [sym_str_lit] = ACTIONS(144),
-    [sym_char_lit] = ACTIONS(144),
-    [sym_null_lit] = ACTIONS(146),
-    [sym_bool_lit] = ACTIONS(144),
-    [anon_sym_SLASH] = ACTIONS(13),
-    [aux_sym__sym_unqualified_token1] = ACTIONS(15),
-    [anon_sym_LPAREN] = ACTIONS(17),
-    [anon_sym_SQUOTE] = ACTIONS(19),
-    [anon_sym_BQUOTE] = ACTIONS(21),
-    [anon_sym_COMMA_AT] = ACTIONS(23),
-    [anon_sym_COMMA] = ACTIONS(25),
-  },
-  [12] = {
-    [sym__gap] = STATE(15),
-    [sym_comment_multiline] = STATE(15),
-    [sym__form] = STATE(29),
-    [sym_kwd_lit] = STATE(29),
-    [sym__kwd_marker] = STATE(35),
-    [sym_sym_lit] = STATE(29),
-    [sym_list_lit] = STATE(29),
-    [sym__bare_list_lit] = STATE(22),
-    [sym_quoting_lit] = STATE(29),
-    [sym_quasi_quoting_lit] = STATE(29),
-    [sym_unquote_splicing_lit] = STATE(29),
-    [sym_unquoting_lit] = STATE(29),
-    [aux_sym_quoting_lit_repeat1] = STATE(15),
-    [sym__ws] = ACTIONS(142),
-    [sym_comment] = ACTIONS(142),
-    [anon_sym_POUND_PIPE] = ACTIONS(7),
-    [sym_num_lit] = ACTIONS(148),
-    [anon_sym_COLON] = ACTIONS(9),
-    [sym_str_lit] = ACTIONS(148),
-    [sym_char_lit] = ACTIONS(148),
-    [sym_null_lit] = ACTIONS(150),
-    [sym_bool_lit] = ACTIONS(148),
-    [anon_sym_SLASH] = ACTIONS(13),
-    [aux_sym__sym_unqualified_token1] = ACTIONS(15),
-    [anon_sym_LPAREN] = ACTIONS(17),
-    [anon_sym_SQUOTE] = ACTIONS(19),
-    [anon_sym_BQUOTE] = ACTIONS(21),
-    [anon_sym_COMMA_AT] = ACTIONS(23),
-    [anon_sym_COMMA] = ACTIONS(25),
-  },
-  [13] = {
-    [sym__gap] = STATE(15),
-    [sym_comment_multiline] = STATE(15),
-    [sym__form] = STATE(28),
-    [sym_kwd_lit] = STATE(28),
-    [sym__kwd_marker] = STATE(35),
-    [sym_sym_lit] = STATE(28),
-    [sym_list_lit] = STATE(28),
-    [sym__bare_list_lit] = STATE(22),
-    [sym_quoting_lit] = STATE(28),
-    [sym_quasi_quoting_lit] = STATE(28),
-    [sym_unquote_splicing_lit] = STATE(28),
-    [sym_unquoting_lit] = STATE(28),
-    [aux_sym_quoting_lit_repeat1] = STATE(15),
-    [sym__ws] = ACTIONS(142),
-    [sym_comment] = ACTIONS(142),
-    [anon_sym_POUND_PIPE] = ACTIONS(7),
-    [sym_num_lit] = ACTIONS(152),
-    [anon_sym_COLON] = ACTIONS(9),
-    [sym_str_lit] = ACTIONS(152),
-    [sym_char_lit] = ACTIONS(152),
-    [sym_null_lit] = ACTIONS(154),
-    [sym_bool_lit] = ACTIONS(152),
-    [anon_sym_SLASH] = ACTIONS(13),
-    [aux_sym__sym_unqualified_token1] = ACTIONS(15),
-    [anon_sym_LPAREN] = ACTIONS(17),
-    [anon_sym_SQUOTE] = ACTIONS(19),
-    [anon_sym_BQUOTE] = ACTIONS(21),
-    [anon_sym_COMMA_AT] = ACTIONS(23),
-    [anon_sym_COMMA] = ACTIONS(25),
-  },
-  [14] = {
-    [sym__gap] = STATE(15),
-    [sym_comment_multiline] = STATE(15),
-    [sym__form] = STATE(26),
-    [sym_kwd_lit] = STATE(26),
-    [sym__kwd_marker] = STATE(35),
-    [sym_sym_lit] = STATE(26),
-    [sym_list_lit] = STATE(26),
-    [sym__bare_list_lit] = STATE(22),
-    [sym_quoting_lit] = STATE(26),
-    [sym_quasi_quoting_lit] = STATE(26),
-    [sym_unquote_splicing_lit] = STATE(26),
-    [sym_unquoting_lit] = STATE(26),
-    [aux_sym_quoting_lit_repeat1] = STATE(15),
-    [sym__ws] = ACTIONS(142),
-    [sym_comment] = ACTIONS(142),
-    [anon_sym_POUND_PIPE] = ACTIONS(7),
-    [sym_num_lit] = ACTIONS(156),
-    [anon_sym_COLON] = ACTIONS(9),
-    [sym_str_lit] = ACTIONS(156),
-    [sym_char_lit] = ACTIONS(156),
-    [sym_null_lit] = ACTIONS(158),
-    [sym_bool_lit] = ACTIONS(156),
-    [anon_sym_SLASH] = ACTIONS(13),
-    [aux_sym__sym_unqualified_token1] = ACTIONS(15),
-    [anon_sym_LPAREN] = ACTIONS(17),
-    [anon_sym_SQUOTE] = ACTIONS(19),
-    [anon_sym_BQUOTE] = ACTIONS(21),
-    [anon_sym_COMMA_AT] = ACTIONS(23),
-    [anon_sym_COMMA] = ACTIONS(25),
+    [anon_sym_SLASH] = ACTIONS(19),
+    [aux_sym__sym_unqualified_token1] = ACTIONS(21),
+    [anon_sym_LPAREN] = ACTIONS(23),
+    [anon_sym_BQUOTE] = ACTIONS(25),
+    [anon_sym_COMMA_AT] = ACTIONS(27),
   },
 };
 
 static const uint16_t ts_small_parse_table[] = {
-  [0] = 5,
-    ACTIONS(163), 1,
-      anon_sym_POUND_PIPE,
-    ACTIONS(160), 2,
+  [0] = 14,
+    ACTIONS(29), 1,
+      aux_sym_num_lit_token1,
+    ACTIONS(33), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(37), 1,
+      anon_sym_POUND,
+    ACTIONS(39), 1,
+      anon_sym_COMMA,
+    ACTIONS(45), 1,
+      anon_sym_DQUOTE,
+    STATE(5), 1,
+      sym_format_prefix_parameters,
+    STATE(21), 1,
+      sym_format_modifiers,
+    STATE(44), 1,
+      sym__format_token,
+    STATE(46), 1,
+      aux_sym_format_modifiers_repeat1,
+    STATE(55), 1,
+      sym_format_directive_type,
+    ACTIONS(31), 2,
+      anon_sym_COLON,
+      anon_sym_AT,
+    ACTIONS(35), 2,
+      anon_sym_v,
+      anon_sym_V,
+    ACTIONS(41), 2,
+      anon_sym_AT_COLON,
+      anon_sym_COLON_AT,
+    ACTIONS(43), 21,
+      anon_sym_TILDE,
+      anon_sym_PERCENT,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      aux_sym_format_directive_type_token1,
+      aux_sym_format_directive_type_token2,
+      anon_sym_LF,
+      anon_sym_CR,
+      aux_sym_format_directive_type_token3,
+      aux_sym_format_directive_type_token4,
+      aux_sym_format_directive_type_token5,
+      aux_sym_format_directive_type_token6,
+      anon_sym__,
+      aux_sym_format_directive_type_token7,
+      aux_sym_format_directive_type_token8,
+      aux_sym_format_directive_type_token9,
+      aux_sym_format_directive_type_token10,
+      anon_sym_SEMI,
+      anon_sym_QMARK,
+      anon_sym_Newline,
+      aux_sym_format_directive_type_token11,
+  [66] = 14,
+    ACTIONS(29), 1,
+      aux_sym_num_lit_token1,
+    ACTIONS(33), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(37), 1,
+      anon_sym_POUND,
+    ACTIONS(39), 1,
+      anon_sym_COMMA,
+    ACTIONS(47), 1,
+      anon_sym_DQUOTE,
+    STATE(5), 1,
+      sym_format_prefix_parameters,
+    STATE(21), 1,
+      sym_format_modifiers,
+    STATE(44), 1,
+      sym__format_token,
+    STATE(46), 1,
+      aux_sym_format_modifiers_repeat1,
+    STATE(55), 1,
+      sym_format_directive_type,
+    ACTIONS(31), 2,
+      anon_sym_COLON,
+      anon_sym_AT,
+    ACTIONS(35), 2,
+      anon_sym_v,
+      anon_sym_V,
+    ACTIONS(41), 2,
+      anon_sym_AT_COLON,
+      anon_sym_COLON_AT,
+    ACTIONS(43), 21,
+      anon_sym_TILDE,
+      anon_sym_PERCENT,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      aux_sym_format_directive_type_token1,
+      aux_sym_format_directive_type_token2,
+      anon_sym_LF,
+      anon_sym_CR,
+      aux_sym_format_directive_type_token3,
+      aux_sym_format_directive_type_token4,
+      aux_sym_format_directive_type_token5,
+      aux_sym_format_directive_type_token6,
+      anon_sym__,
+      aux_sym_format_directive_type_token7,
+      aux_sym_format_directive_type_token8,
+      aux_sym_format_directive_type_token9,
+      aux_sym_format_directive_type_token10,
+      anon_sym_SEMI,
+      anon_sym_QMARK,
+      anon_sym_Newline,
+      aux_sym_format_directive_type_token11,
+  [132] = 13,
+    ACTIONS(29), 1,
+      aux_sym_num_lit_token1,
+    ACTIONS(33), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(37), 1,
+      anon_sym_POUND,
+    ACTIONS(39), 1,
+      anon_sym_COMMA,
+    STATE(5), 1,
+      sym_format_prefix_parameters,
+    STATE(21), 1,
+      sym_format_modifiers,
+    STATE(44), 1,
+      sym__format_token,
+    STATE(46), 1,
+      aux_sym_format_modifiers_repeat1,
+    STATE(55), 1,
+      sym_format_directive_type,
+    ACTIONS(31), 2,
+      anon_sym_COLON,
+      anon_sym_AT,
+    ACTIONS(35), 2,
+      anon_sym_v,
+      anon_sym_V,
+    ACTIONS(41), 2,
+      anon_sym_AT_COLON,
+      anon_sym_COLON_AT,
+    ACTIONS(43), 21,
+      anon_sym_TILDE,
+      anon_sym_PERCENT,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      aux_sym_format_directive_type_token1,
+      aux_sym_format_directive_type_token2,
+      anon_sym_LF,
+      anon_sym_CR,
+      aux_sym_format_directive_type_token3,
+      aux_sym_format_directive_type_token4,
+      aux_sym_format_directive_type_token5,
+      aux_sym_format_directive_type_token6,
+      anon_sym__,
+      aux_sym_format_directive_type_token7,
+      aux_sym_format_directive_type_token8,
+      aux_sym_format_directive_type_token9,
+      aux_sym_format_directive_type_token10,
+      anon_sym_SEMI,
+      anon_sym_QMARK,
+      anon_sym_Newline,
+      aux_sym_format_directive_type_token11,
+  [195] = 10,
+    ACTIONS(29), 1,
+      aux_sym_num_lit_token1,
+    ACTIONS(33), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(39), 1,
+      anon_sym_COMMA,
+    STATE(20), 1,
+      sym_format_modifiers,
+    STATE(44), 1,
+      sym__format_token,
+    STATE(46), 1,
+      aux_sym_format_modifiers_repeat1,
+    STATE(54), 1,
+      sym_format_directive_type,
+    ACTIONS(31), 2,
+      anon_sym_COLON,
+      anon_sym_AT,
+    ACTIONS(41), 2,
+      anon_sym_AT_COLON,
+      anon_sym_COLON_AT,
+    ACTIONS(43), 21,
+      anon_sym_TILDE,
+      anon_sym_PERCENT,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      aux_sym_format_directive_type_token1,
+      aux_sym_format_directive_type_token2,
+      anon_sym_LF,
+      anon_sym_CR,
+      aux_sym_format_directive_type_token3,
+      aux_sym_format_directive_type_token4,
+      aux_sym_format_directive_type_token5,
+      aux_sym_format_directive_type_token6,
+      anon_sym__,
+      aux_sym_format_directive_type_token7,
+      aux_sym_format_directive_type_token8,
+      aux_sym_format_directive_type_token9,
+      aux_sym_format_directive_type_token10,
+      anon_sym_SEMI,
+      anon_sym_QMARK,
+      anon_sym_Newline,
+      aux_sym_format_directive_type_token11,
+  [248] = 16,
+    ACTIONS(49), 1,
+      ts_builtin_sym_end,
+    ACTIONS(54), 1,
+      aux_sym_num_lit_token1,
+    ACTIONS(57), 1,
+      anon_sym_COLON,
+    ACTIONS(60), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(63), 1,
+      anon_sym_COMMA,
+    ACTIONS(66), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(69), 1,
+      sym_null_lit,
+    ACTIONS(72), 1,
+      anon_sym_SLASH,
+    ACTIONS(75), 1,
+      aux_sym__sym_unqualified_token1,
+    ACTIONS(78), 1,
+      anon_sym_LPAREN,
+    ACTIONS(81), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(84), 1,
+      anon_sym_COMMA_AT,
+    STATE(33), 1,
+      sym__bare_list_lit,
+    STATE(59), 1,
+      sym__kwd_marker,
+    ACTIONS(51), 5,
       sym__ws,
       sym_comment,
-    ACTIONS(168), 3,
-      sym_null_lit,
-      aux_sym__sym_unqualified_token1,
-      anon_sym_COMMA,
-    STATE(15), 3,
+      sym_block_comment,
+      sym_char_lit,
+      sym_bool_lit,
+    STATE(6), 12,
       sym__gap,
-      sym_comment_multiline,
+      sym__form,
+      sym_num_lit,
+      sym_kwd_lit,
+      sym_str_lit,
+      sym_sym_lit,
+      sym_list_lit,
+      sym_quoting_lit,
+      sym_quasi_quoting_lit,
+      sym_unquote_splicing_lit,
+      sym_unquoting_lit,
+      aux_sym_source_repeat1,
+  [312] = 18,
+    ACTIONS(7), 1,
+      aux_sym_num_lit_token1,
+    ACTIONS(9), 1,
+      anon_sym_COLON,
+    ACTIONS(11), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(13), 1,
+      anon_sym_COMMA,
+    ACTIONS(15), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(19), 1,
+      anon_sym_SLASH,
+    ACTIONS(21), 1,
+      aux_sym__sym_unqualified_token1,
+    ACTIONS(23), 1,
+      anon_sym_LPAREN,
+    ACTIONS(25), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(27), 1,
+      anon_sym_COMMA_AT,
+    ACTIONS(91), 1,
+      sym_null_lit,
+    ACTIONS(93), 1,
+      anon_sym_RPAREN,
+    STATE(33), 1,
+      sym__bare_list_lit,
+    STATE(59), 1,
+      sym__kwd_marker,
+    ACTIONS(89), 2,
+      sym_char_lit,
+      sym_bool_lit,
+    STATE(9), 2,
+      sym__gap,
+      aux_sym__bare_list_lit_repeat1,
+    ACTIONS(87), 3,
+      sym__ws,
+      sym_comment,
+      sym_block_comment,
+    STATE(42), 10,
+      sym__form,
+      sym_num_lit,
+      sym_kwd_lit,
+      sym_str_lit,
+      sym_sym_lit,
+      sym_list_lit,
+      sym_quoting_lit,
+      sym_quasi_quoting_lit,
+      sym_unquote_splicing_lit,
+      sym_unquoting_lit,
+  [380] = 18,
+    ACTIONS(7), 1,
+      aux_sym_num_lit_token1,
+    ACTIONS(9), 1,
+      anon_sym_COLON,
+    ACTIONS(11), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(13), 1,
+      anon_sym_COMMA,
+    ACTIONS(15), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(19), 1,
+      anon_sym_SLASH,
+    ACTIONS(21), 1,
+      aux_sym__sym_unqualified_token1,
+    ACTIONS(23), 1,
+      anon_sym_LPAREN,
+    ACTIONS(25), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(27), 1,
+      anon_sym_COMMA_AT,
+    ACTIONS(91), 1,
+      sym_null_lit,
+    ACTIONS(97), 1,
+      anon_sym_RPAREN,
+    STATE(33), 1,
+      sym__bare_list_lit,
+    STATE(59), 1,
+      sym__kwd_marker,
+    ACTIONS(89), 2,
+      sym_char_lit,
+      sym_bool_lit,
+    STATE(7), 2,
+      sym__gap,
+      aux_sym__bare_list_lit_repeat1,
+    ACTIONS(95), 3,
+      sym__ws,
+      sym_comment,
+      sym_block_comment,
+    STATE(42), 10,
+      sym__form,
+      sym_num_lit,
+      sym_kwd_lit,
+      sym_str_lit,
+      sym_sym_lit,
+      sym_list_lit,
+      sym_quoting_lit,
+      sym_quasi_quoting_lit,
+      sym_unquote_splicing_lit,
+      sym_unquoting_lit,
+  [448] = 18,
+    ACTIONS(102), 1,
+      aux_sym_num_lit_token1,
+    ACTIONS(105), 1,
+      anon_sym_COLON,
+    ACTIONS(108), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(111), 1,
+      anon_sym_COMMA,
+    ACTIONS(114), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(120), 1,
+      sym_null_lit,
+    ACTIONS(123), 1,
+      anon_sym_SLASH,
+    ACTIONS(126), 1,
+      aux_sym__sym_unqualified_token1,
+    ACTIONS(129), 1,
+      anon_sym_LPAREN,
+    ACTIONS(132), 1,
+      anon_sym_RPAREN,
+    ACTIONS(134), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(137), 1,
+      anon_sym_COMMA_AT,
+    STATE(33), 1,
+      sym__bare_list_lit,
+    STATE(59), 1,
+      sym__kwd_marker,
+    ACTIONS(117), 2,
+      sym_char_lit,
+      sym_bool_lit,
+    STATE(9), 2,
+      sym__gap,
+      aux_sym__bare_list_lit_repeat1,
+    ACTIONS(99), 3,
+      sym__ws,
+      sym_comment,
+      sym_block_comment,
+    STATE(42), 10,
+      sym__form,
+      sym_num_lit,
+      sym_kwd_lit,
+      sym_str_lit,
+      sym_sym_lit,
+      sym_list_lit,
+      sym_quoting_lit,
+      sym_quasi_quoting_lit,
+      sym_unquote_splicing_lit,
+      sym_unquoting_lit,
+  [516] = 16,
+    ACTIONS(7), 1,
+      aux_sym_num_lit_token1,
+    ACTIONS(9), 1,
+      anon_sym_COLON,
+    ACTIONS(11), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(13), 1,
+      anon_sym_COMMA,
+    ACTIONS(15), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(19), 1,
+      anon_sym_SLASH,
+    ACTIONS(21), 1,
+      aux_sym__sym_unqualified_token1,
+    ACTIONS(23), 1,
+      anon_sym_LPAREN,
+    ACTIONS(25), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(27), 1,
+      anon_sym_COMMA_AT,
+    ACTIONS(140), 1,
+      ts_builtin_sym_end,
+    ACTIONS(144), 1,
+      sym_null_lit,
+    STATE(33), 1,
+      sym__bare_list_lit,
+    STATE(59), 1,
+      sym__kwd_marker,
+    ACTIONS(142), 5,
+      sym__ws,
+      sym_comment,
+      sym_block_comment,
+      sym_char_lit,
+      sym_bool_lit,
+    STATE(6), 12,
+      sym__gap,
+      sym__form,
+      sym_num_lit,
+      sym_kwd_lit,
+      sym_str_lit,
+      sym_sym_lit,
+      sym_list_lit,
+      sym_quoting_lit,
+      sym_quasi_quoting_lit,
+      sym_unquote_splicing_lit,
+      sym_unquoting_lit,
+      aux_sym_source_repeat1,
+  [580] = 17,
+    ACTIONS(7), 1,
+      aux_sym_num_lit_token1,
+    ACTIONS(9), 1,
+      anon_sym_COLON,
+    ACTIONS(11), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(13), 1,
+      anon_sym_COMMA,
+    ACTIONS(15), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(19), 1,
+      anon_sym_SLASH,
+    ACTIONS(21), 1,
+      aux_sym__sym_unqualified_token1,
+    ACTIONS(23), 1,
+      anon_sym_LPAREN,
+    ACTIONS(25), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(27), 1,
+      anon_sym_COMMA_AT,
+    ACTIONS(150), 1,
+      sym_null_lit,
+    STATE(33), 1,
+      sym__bare_list_lit,
+    STATE(59), 1,
+      sym__kwd_marker,
+    ACTIONS(148), 2,
+      sym_char_lit,
+      sym_bool_lit,
+    STATE(16), 2,
+      sym__gap,
       aux_sym_quoting_lit_repeat1,
-    ACTIONS(166), 10,
-      sym_num_lit,
-      anon_sym_COLON,
-      sym_str_lit,
-      sym_char_lit,
-      sym_bool_lit,
-      anon_sym_SLASH,
-      anon_sym_LPAREN,
-      anon_sym_SQUOTE,
-      anon_sym_BQUOTE,
-      anon_sym_COMMA_AT,
-  [30] = 2,
-    ACTIONS(172), 3,
-      sym_null_lit,
-      aux_sym__sym_unqualified_token1,
-      anon_sym_COMMA,
-    ACTIONS(170), 15,
-      ts_builtin_sym_end,
+    ACTIONS(146), 3,
       sym__ws,
       sym_comment,
-      anon_sym_POUND_PIPE,
+      sym_block_comment,
+    STATE(41), 10,
+      sym__form,
       sym_num_lit,
-      anon_sym_COLON,
+      sym_kwd_lit,
       sym_str_lit,
+      sym_sym_lit,
+      sym_list_lit,
+      sym_quoting_lit,
+      sym_quasi_quoting_lit,
+      sym_unquote_splicing_lit,
+      sym_unquoting_lit,
+  [645] = 17,
+    ACTIONS(7), 1,
+      aux_sym_num_lit_token1,
+    ACTIONS(9), 1,
+      anon_sym_COLON,
+    ACTIONS(11), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(13), 1,
+      anon_sym_COMMA,
+    ACTIONS(15), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(19), 1,
+      anon_sym_SLASH,
+    ACTIONS(21), 1,
+      aux_sym__sym_unqualified_token1,
+    ACTIONS(23), 1,
+      anon_sym_LPAREN,
+    ACTIONS(25), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(27), 1,
+      anon_sym_COMMA_AT,
+    ACTIONS(156), 1,
+      sym_null_lit,
+    STATE(33), 1,
+      sym__bare_list_lit,
+    STATE(59), 1,
+      sym__kwd_marker,
+    ACTIONS(154), 2,
       sym_char_lit,
       sym_bool_lit,
-      anon_sym_SLASH,
-      anon_sym_LPAREN,
-      anon_sym_RPAREN,
-      anon_sym_SQUOTE,
-      anon_sym_BQUOTE,
-      anon_sym_COMMA_AT,
-  [53] = 2,
-    ACTIONS(176), 3,
-      sym_null_lit,
-      aux_sym__sym_unqualified_token1,
-      anon_sym_COMMA,
-    ACTIONS(174), 15,
-      ts_builtin_sym_end,
+    STATE(17), 2,
+      sym__gap,
+      aux_sym_quoting_lit_repeat1,
+    ACTIONS(152), 3,
       sym__ws,
       sym_comment,
-      anon_sym_POUND_PIPE,
+      sym_block_comment,
+    STATE(40), 10,
+      sym__form,
       sym_num_lit,
-      anon_sym_COLON,
+      sym_kwd_lit,
       sym_str_lit,
+      sym_sym_lit,
+      sym_list_lit,
+      sym_quoting_lit,
+      sym_quasi_quoting_lit,
+      sym_unquote_splicing_lit,
+      sym_unquoting_lit,
+  [710] = 17,
+    ACTIONS(7), 1,
+      aux_sym_num_lit_token1,
+    ACTIONS(9), 1,
+      anon_sym_COLON,
+    ACTIONS(11), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(13), 1,
+      anon_sym_COMMA,
+    ACTIONS(15), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(19), 1,
+      anon_sym_SLASH,
+    ACTIONS(21), 1,
+      aux_sym__sym_unqualified_token1,
+    ACTIONS(23), 1,
+      anon_sym_LPAREN,
+    ACTIONS(25), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(27), 1,
+      anon_sym_COMMA_AT,
+    ACTIONS(162), 1,
+      sym_null_lit,
+    STATE(33), 1,
+      sym__bare_list_lit,
+    STATE(59), 1,
+      sym__kwd_marker,
+    ACTIONS(160), 2,
       sym_char_lit,
       sym_bool_lit,
-      anon_sym_SLASH,
-      anon_sym_LPAREN,
-      anon_sym_RPAREN,
-      anon_sym_SQUOTE,
-      anon_sym_BQUOTE,
-      anon_sym_COMMA_AT,
-  [76] = 2,
-    ACTIONS(180), 3,
-      sym_null_lit,
-      aux_sym__sym_unqualified_token1,
-      anon_sym_COMMA,
-    ACTIONS(178), 15,
-      ts_builtin_sym_end,
+    STATE(18), 2,
+      sym__gap,
+      aux_sym_quoting_lit_repeat1,
+    ACTIONS(158), 3,
       sym__ws,
       sym_comment,
-      anon_sym_POUND_PIPE,
+      sym_block_comment,
+    STATE(28), 10,
+      sym__form,
       sym_num_lit,
-      anon_sym_COLON,
+      sym_kwd_lit,
       sym_str_lit,
+      sym_sym_lit,
+      sym_list_lit,
+      sym_quoting_lit,
+      sym_quasi_quoting_lit,
+      sym_unquote_splicing_lit,
+      sym_unquoting_lit,
+  [775] = 17,
+    ACTIONS(7), 1,
+      aux_sym_num_lit_token1,
+    ACTIONS(9), 1,
+      anon_sym_COLON,
+    ACTIONS(11), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(13), 1,
+      anon_sym_COMMA,
+    ACTIONS(15), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(19), 1,
+      anon_sym_SLASH,
+    ACTIONS(21), 1,
+      aux_sym__sym_unqualified_token1,
+    ACTIONS(23), 1,
+      anon_sym_LPAREN,
+    ACTIONS(25), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(27), 1,
+      anon_sym_COMMA_AT,
+    ACTIONS(168), 1,
+      sym_null_lit,
+    STATE(33), 1,
+      sym__bare_list_lit,
+    STATE(59), 1,
+      sym__kwd_marker,
+    ACTIONS(166), 2,
       sym_char_lit,
       sym_bool_lit,
-      anon_sym_SLASH,
-      anon_sym_LPAREN,
-      anon_sym_RPAREN,
-      anon_sym_SQUOTE,
-      anon_sym_BQUOTE,
-      anon_sym_COMMA_AT,
-  [99] = 2,
-    ACTIONS(184), 3,
-      sym_null_lit,
-      aux_sym__sym_unqualified_token1,
-      anon_sym_COMMA,
-    ACTIONS(182), 15,
-      ts_builtin_sym_end,
+    STATE(15), 2,
+      sym__gap,
+      aux_sym_quoting_lit_repeat1,
+    ACTIONS(164), 3,
       sym__ws,
       sym_comment,
-      anon_sym_POUND_PIPE,
+      sym_block_comment,
+    STATE(29), 10,
+      sym__form,
       sym_num_lit,
-      anon_sym_COLON,
+      sym_kwd_lit,
       sym_str_lit,
+      sym_sym_lit,
+      sym_list_lit,
+      sym_quoting_lit,
+      sym_quasi_quoting_lit,
+      sym_unquote_splicing_lit,
+      sym_unquoting_lit,
+  [840] = 17,
+    ACTIONS(7), 1,
+      aux_sym_num_lit_token1,
+    ACTIONS(9), 1,
+      anon_sym_COLON,
+    ACTIONS(11), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(13), 1,
+      anon_sym_COMMA,
+    ACTIONS(15), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(19), 1,
+      anon_sym_SLASH,
+    ACTIONS(21), 1,
+      aux_sym__sym_unqualified_token1,
+    ACTIONS(23), 1,
+      anon_sym_LPAREN,
+    ACTIONS(25), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(27), 1,
+      anon_sym_COMMA_AT,
+    ACTIONS(174), 1,
+      sym_null_lit,
+    STATE(33), 1,
+      sym__bare_list_lit,
+    STATE(59), 1,
+      sym__kwd_marker,
+    ACTIONS(172), 2,
       sym_char_lit,
       sym_bool_lit,
-      anon_sym_SLASH,
-      anon_sym_LPAREN,
-      anon_sym_RPAREN,
-      anon_sym_SQUOTE,
-      anon_sym_BQUOTE,
-      anon_sym_COMMA_AT,
-  [122] = 2,
-    ACTIONS(188), 3,
-      sym_null_lit,
-      aux_sym__sym_unqualified_token1,
-      anon_sym_COMMA,
-    ACTIONS(186), 15,
-      ts_builtin_sym_end,
+    STATE(31), 2,
+      sym__gap,
+      aux_sym_quoting_lit_repeat1,
+    ACTIONS(170), 3,
       sym__ws,
       sym_comment,
-      anon_sym_POUND_PIPE,
+      sym_block_comment,
+    STATE(39), 10,
+      sym__form,
       sym_num_lit,
-      anon_sym_COLON,
+      sym_kwd_lit,
       sym_str_lit,
+      sym_sym_lit,
+      sym_list_lit,
+      sym_quoting_lit,
+      sym_quasi_quoting_lit,
+      sym_unquote_splicing_lit,
+      sym_unquoting_lit,
+  [905] = 17,
+    ACTIONS(7), 1,
+      aux_sym_num_lit_token1,
+    ACTIONS(9), 1,
+      anon_sym_COLON,
+    ACTIONS(11), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(13), 1,
+      anon_sym_COMMA,
+    ACTIONS(15), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(19), 1,
+      anon_sym_SLASH,
+    ACTIONS(21), 1,
+      aux_sym__sym_unqualified_token1,
+    ACTIONS(23), 1,
+      anon_sym_LPAREN,
+    ACTIONS(25), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(27), 1,
+      anon_sym_COMMA_AT,
+    ACTIONS(178), 1,
+      sym_null_lit,
+    STATE(33), 1,
+      sym__bare_list_lit,
+    STATE(59), 1,
+      sym__kwd_marker,
+    ACTIONS(176), 2,
       sym_char_lit,
       sym_bool_lit,
-      anon_sym_SLASH,
-      anon_sym_LPAREN,
-      anon_sym_RPAREN,
-      anon_sym_SQUOTE,
-      anon_sym_BQUOTE,
-      anon_sym_COMMA_AT,
-  [145] = 2,
-    ACTIONS(192), 3,
-      sym_null_lit,
-      aux_sym__sym_unqualified_token1,
-      anon_sym_COMMA,
-    ACTIONS(190), 15,
-      ts_builtin_sym_end,
+    STATE(31), 2,
+      sym__gap,
+      aux_sym_quoting_lit_repeat1,
+    ACTIONS(170), 3,
       sym__ws,
       sym_comment,
-      anon_sym_POUND_PIPE,
+      sym_block_comment,
+    STATE(24), 10,
+      sym__form,
       sym_num_lit,
-      anon_sym_COLON,
+      sym_kwd_lit,
       sym_str_lit,
+      sym_sym_lit,
+      sym_list_lit,
+      sym_quoting_lit,
+      sym_quasi_quoting_lit,
+      sym_unquote_splicing_lit,
+      sym_unquoting_lit,
+  [970] = 17,
+    ACTIONS(7), 1,
+      aux_sym_num_lit_token1,
+    ACTIONS(9), 1,
+      anon_sym_COLON,
+    ACTIONS(11), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(13), 1,
+      anon_sym_COMMA,
+    ACTIONS(15), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(19), 1,
+      anon_sym_SLASH,
+    ACTIONS(21), 1,
+      aux_sym__sym_unqualified_token1,
+    ACTIONS(23), 1,
+      anon_sym_LPAREN,
+    ACTIONS(25), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(27), 1,
+      anon_sym_COMMA_AT,
+    ACTIONS(182), 1,
+      sym_null_lit,
+    STATE(33), 1,
+      sym__bare_list_lit,
+    STATE(59), 1,
+      sym__kwd_marker,
+    ACTIONS(180), 2,
       sym_char_lit,
       sym_bool_lit,
-      anon_sym_SLASH,
-      anon_sym_LPAREN,
-      anon_sym_RPAREN,
-      anon_sym_SQUOTE,
-      anon_sym_BQUOTE,
-      anon_sym_COMMA_AT,
-  [168] = 2,
-    ACTIONS(196), 3,
-      sym_null_lit,
-      aux_sym__sym_unqualified_token1,
-      anon_sym_COMMA,
-    ACTIONS(194), 15,
-      ts_builtin_sym_end,
+    STATE(31), 2,
+      sym__gap,
+      aux_sym_quoting_lit_repeat1,
+    ACTIONS(170), 3,
       sym__ws,
       sym_comment,
-      anon_sym_POUND_PIPE,
+      sym_block_comment,
+    STATE(32), 10,
+      sym__form,
       sym_num_lit,
-      anon_sym_COLON,
+      sym_kwd_lit,
       sym_str_lit,
+      sym_sym_lit,
+      sym_list_lit,
+      sym_quoting_lit,
+      sym_quasi_quoting_lit,
+      sym_unquote_splicing_lit,
+      sym_unquoting_lit,
+  [1035] = 17,
+    ACTIONS(7), 1,
+      aux_sym_num_lit_token1,
+    ACTIONS(9), 1,
+      anon_sym_COLON,
+    ACTIONS(11), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(13), 1,
+      anon_sym_COMMA,
+    ACTIONS(15), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(19), 1,
+      anon_sym_SLASH,
+    ACTIONS(21), 1,
+      aux_sym__sym_unqualified_token1,
+    ACTIONS(23), 1,
+      anon_sym_LPAREN,
+    ACTIONS(25), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(27), 1,
+      anon_sym_COMMA_AT,
+    ACTIONS(186), 1,
+      sym_null_lit,
+    STATE(33), 1,
+      sym__bare_list_lit,
+    STATE(59), 1,
+      sym__kwd_marker,
+    ACTIONS(184), 2,
       sym_char_lit,
       sym_bool_lit,
-      anon_sym_SLASH,
-      anon_sym_LPAREN,
-      anon_sym_RPAREN,
+    STATE(31), 2,
+      sym__gap,
+      aux_sym_quoting_lit_repeat1,
+    ACTIONS(170), 3,
+      sym__ws,
+      sym_comment,
+      sym_block_comment,
+    STATE(27), 10,
+      sym__form,
+      sym_num_lit,
+      sym_kwd_lit,
+      sym_str_lit,
+      sym_sym_lit,
+      sym_list_lit,
+      sym_quoting_lit,
+      sym_quasi_quoting_lit,
+      sym_unquote_splicing_lit,
+      sym_unquoting_lit,
+  [1100] = 2,
+    ACTIONS(190), 2,
+      anon_sym_COLON,
+      anon_sym_AT,
+    ACTIONS(188), 26,
+      aux_sym_num_lit_token1,
       anon_sym_SQUOTE,
-      anon_sym_BQUOTE,
-      anon_sym_COMMA_AT,
-  [191] = 2,
+      anon_sym_COMMA,
+      anon_sym_AT_COLON,
+      anon_sym_COLON_AT,
+      anon_sym_TILDE,
+      anon_sym_PERCENT,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      aux_sym_format_directive_type_token1,
+      aux_sym_format_directive_type_token2,
+      anon_sym_LF,
+      anon_sym_CR,
+      aux_sym_format_directive_type_token3,
+      aux_sym_format_directive_type_token4,
+      aux_sym_format_directive_type_token5,
+      aux_sym_format_directive_type_token6,
+      anon_sym__,
+      aux_sym_format_directive_type_token7,
+      aux_sym_format_directive_type_token8,
+      aux_sym_format_directive_type_token9,
+      aux_sym_format_directive_type_token10,
+      anon_sym_SEMI,
+      anon_sym_QMARK,
+      anon_sym_Newline,
+      aux_sym_format_directive_type_token11,
+  [1133] = 7,
+    ACTIONS(29), 1,
+      aux_sym_num_lit_token1,
+    ACTIONS(33), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(192), 1,
+      anon_sym_COMMA,
+    STATE(44), 1,
+      sym__format_token,
+    STATE(50), 1,
+      aux_sym_format_modifiers_repeat1,
+    STATE(58), 1,
+      sym_format_directive_type,
+    ACTIONS(43), 21,
+      anon_sym_TILDE,
+      anon_sym_PERCENT,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      aux_sym_format_directive_type_token1,
+      aux_sym_format_directive_type_token2,
+      anon_sym_LF,
+      anon_sym_CR,
+      aux_sym_format_directive_type_token3,
+      aux_sym_format_directive_type_token4,
+      aux_sym_format_directive_type_token5,
+      aux_sym_format_directive_type_token6,
+      anon_sym__,
+      aux_sym_format_directive_type_token7,
+      aux_sym_format_directive_type_token8,
+      aux_sym_format_directive_type_token9,
+      aux_sym_format_directive_type_token10,
+      anon_sym_SEMI,
+      anon_sym_QMARK,
+      anon_sym_Newline,
+      aux_sym_format_directive_type_token11,
+  [1175] = 7,
+    ACTIONS(29), 1,
+      aux_sym_num_lit_token1,
+    ACTIONS(33), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(192), 1,
+      anon_sym_COMMA,
+    STATE(44), 1,
+      sym__format_token,
+    STATE(50), 1,
+      aux_sym_format_modifiers_repeat1,
+    STATE(54), 1,
+      sym_format_directive_type,
+    ACTIONS(43), 21,
+      anon_sym_TILDE,
+      anon_sym_PERCENT,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      aux_sym_format_directive_type_token1,
+      aux_sym_format_directive_type_token2,
+      anon_sym_LF,
+      anon_sym_CR,
+      aux_sym_format_directive_type_token3,
+      aux_sym_format_directive_type_token4,
+      aux_sym_format_directive_type_token5,
+      aux_sym_format_directive_type_token6,
+      anon_sym__,
+      aux_sym_format_directive_type_token7,
+      aux_sym_format_directive_type_token8,
+      aux_sym_format_directive_type_token9,
+      aux_sym_format_directive_type_token10,
+      anon_sym_SEMI,
+      anon_sym_QMARK,
+      anon_sym_Newline,
+      aux_sym_format_directive_type_token11,
+  [1217] = 1,
+    ACTIONS(194), 24,
+      aux_sym_num_lit_token1,
+      anon_sym_SQUOTE,
+      anon_sym_COMMA,
+      anon_sym_TILDE,
+      anon_sym_PERCENT,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      aux_sym_format_directive_type_token1,
+      aux_sym_format_directive_type_token2,
+      anon_sym_LF,
+      anon_sym_CR,
+      aux_sym_format_directive_type_token3,
+      aux_sym_format_directive_type_token4,
+      aux_sym_format_directive_type_token5,
+      aux_sym_format_directive_type_token6,
+      anon_sym__,
+      aux_sym_format_directive_type_token7,
+      aux_sym_format_directive_type_token8,
+      aux_sym_format_directive_type_token9,
+      aux_sym_format_directive_type_token10,
+      anon_sym_SEMI,
+      anon_sym_QMARK,
+      anon_sym_Newline,
+      aux_sym_format_directive_type_token11,
+  [1244] = 1,
+    ACTIONS(196), 24,
+      aux_sym_num_lit_token1,
+      anon_sym_SQUOTE,
+      anon_sym_COMMA,
+      anon_sym_TILDE,
+      anon_sym_PERCENT,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      aux_sym_format_directive_type_token1,
+      aux_sym_format_directive_type_token2,
+      anon_sym_LF,
+      anon_sym_CR,
+      aux_sym_format_directive_type_token3,
+      aux_sym_format_directive_type_token4,
+      aux_sym_format_directive_type_token5,
+      aux_sym_format_directive_type_token6,
+      anon_sym__,
+      aux_sym_format_directive_type_token7,
+      aux_sym_format_directive_type_token8,
+      aux_sym_format_directive_type_token9,
+      aux_sym_format_directive_type_token10,
+      anon_sym_SEMI,
+      anon_sym_QMARK,
+      anon_sym_Newline,
+      aux_sym_format_directive_type_token11,
+  [1271] = 2,
     ACTIONS(200), 3,
+      anon_sym_COMMA,
       sym_null_lit,
       aux_sym__sym_unqualified_token1,
-      anon_sym_COMMA,
     ACTIONS(198), 15,
       ts_builtin_sym_end,
       sym__ws,
       sym_comment,
-      anon_sym_POUND_PIPE,
-      sym_num_lit,
+      sym_block_comment,
+      aux_sym_num_lit_token1,
       anon_sym_COLON,
-      sym_str_lit,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
       sym_char_lit,
       sym_bool_lit,
       anon_sym_SLASH,
       anon_sym_LPAREN,
       anon_sym_RPAREN,
-      anon_sym_SQUOTE,
       anon_sym_BQUOTE,
       anon_sym_COMMA_AT,
-  [214] = 2,
+  [1294] = 2,
     ACTIONS(204), 3,
+      anon_sym_COMMA,
       sym_null_lit,
       aux_sym__sym_unqualified_token1,
-      anon_sym_COMMA,
     ACTIONS(202), 15,
       ts_builtin_sym_end,
       sym__ws,
       sym_comment,
-      anon_sym_POUND_PIPE,
-      sym_num_lit,
+      sym_block_comment,
+      aux_sym_num_lit_token1,
       anon_sym_COLON,
-      sym_str_lit,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
       sym_char_lit,
       sym_bool_lit,
       anon_sym_SLASH,
       anon_sym_LPAREN,
       anon_sym_RPAREN,
-      anon_sym_SQUOTE,
       anon_sym_BQUOTE,
       anon_sym_COMMA_AT,
-  [237] = 2,
+  [1317] = 2,
     ACTIONS(208), 3,
+      anon_sym_COMMA,
       sym_null_lit,
       aux_sym__sym_unqualified_token1,
-      anon_sym_COMMA,
     ACTIONS(206), 15,
       ts_builtin_sym_end,
       sym__ws,
       sym_comment,
-      anon_sym_POUND_PIPE,
-      sym_num_lit,
+      sym_block_comment,
+      aux_sym_num_lit_token1,
       anon_sym_COLON,
-      sym_str_lit,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
       sym_char_lit,
       sym_bool_lit,
       anon_sym_SLASH,
       anon_sym_LPAREN,
       anon_sym_RPAREN,
-      anon_sym_SQUOTE,
       anon_sym_BQUOTE,
       anon_sym_COMMA_AT,
-  [260] = 2,
+  [1340] = 2,
     ACTIONS(212), 3,
+      anon_sym_COMMA,
       sym_null_lit,
       aux_sym__sym_unqualified_token1,
-      anon_sym_COMMA,
     ACTIONS(210), 15,
       ts_builtin_sym_end,
       sym__ws,
       sym_comment,
-      anon_sym_POUND_PIPE,
-      sym_num_lit,
+      sym_block_comment,
+      aux_sym_num_lit_token1,
       anon_sym_COLON,
-      sym_str_lit,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
       sym_char_lit,
       sym_bool_lit,
       anon_sym_SLASH,
       anon_sym_LPAREN,
       anon_sym_RPAREN,
-      anon_sym_SQUOTE,
       anon_sym_BQUOTE,
       anon_sym_COMMA_AT,
-  [283] = 2,
+  [1363] = 2,
     ACTIONS(216), 3,
+      anon_sym_COMMA,
       sym_null_lit,
       aux_sym__sym_unqualified_token1,
-      anon_sym_COMMA,
     ACTIONS(214), 15,
       ts_builtin_sym_end,
       sym__ws,
       sym_comment,
-      anon_sym_POUND_PIPE,
-      sym_num_lit,
+      sym_block_comment,
+      aux_sym_num_lit_token1,
       anon_sym_COLON,
-      sym_str_lit,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
       sym_char_lit,
       sym_bool_lit,
       anon_sym_SLASH,
       anon_sym_LPAREN,
       anon_sym_RPAREN,
-      anon_sym_SQUOTE,
       anon_sym_BQUOTE,
       anon_sym_COMMA_AT,
-  [306] = 2,
+  [1386] = 2,
     ACTIONS(220), 3,
+      anon_sym_COMMA,
       sym_null_lit,
       aux_sym__sym_unqualified_token1,
-      anon_sym_COMMA,
     ACTIONS(218), 15,
       ts_builtin_sym_end,
       sym__ws,
       sym_comment,
-      anon_sym_POUND_PIPE,
-      sym_num_lit,
+      sym_block_comment,
+      aux_sym_num_lit_token1,
       anon_sym_COLON,
-      sym_str_lit,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
       sym_char_lit,
       sym_bool_lit,
       anon_sym_SLASH,
       anon_sym_LPAREN,
       anon_sym_RPAREN,
-      anon_sym_SQUOTE,
       anon_sym_BQUOTE,
       anon_sym_COMMA_AT,
-  [329] = 2,
+  [1409] = 2,
     ACTIONS(224), 3,
+      anon_sym_COMMA,
       sym_null_lit,
       aux_sym__sym_unqualified_token1,
-      anon_sym_COMMA,
     ACTIONS(222), 15,
       ts_builtin_sym_end,
       sym__ws,
       sym_comment,
-      anon_sym_POUND_PIPE,
-      sym_num_lit,
+      sym_block_comment,
+      aux_sym_num_lit_token1,
       anon_sym_COLON,
-      sym_str_lit,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
       sym_char_lit,
       sym_bool_lit,
       anon_sym_SLASH,
       anon_sym_LPAREN,
       anon_sym_RPAREN,
-      anon_sym_SQUOTE,
       anon_sym_BQUOTE,
       anon_sym_COMMA_AT,
-  [352] = 2,
-    ACTIONS(228), 3,
+  [1432] = 4,
+    STATE(31), 2,
+      sym__gap,
+      aux_sym_quoting_lit_repeat1,
+    ACTIONS(226), 3,
+      sym__ws,
+      sym_comment,
+      sym_block_comment,
+    ACTIONS(231), 3,
+      anon_sym_COMMA,
       sym_null_lit,
       aux_sym__sym_unqualified_token1,
+    ACTIONS(229), 10,
+      aux_sym_num_lit_token1,
+      anon_sym_COLON,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+      sym_char_lit,
+      sym_bool_lit,
+      anon_sym_SLASH,
+      anon_sym_LPAREN,
+      anon_sym_BQUOTE,
+      anon_sym_COMMA_AT,
+  [1459] = 2,
+    ACTIONS(235), 3,
       anon_sym_COMMA,
-    ACTIONS(226), 15,
+      sym_null_lit,
+      aux_sym__sym_unqualified_token1,
+    ACTIONS(233), 15,
       ts_builtin_sym_end,
       sym__ws,
       sym_comment,
-      anon_sym_POUND_PIPE,
-      sym_num_lit,
+      sym_block_comment,
+      aux_sym_num_lit_token1,
       anon_sym_COLON,
-      sym_str_lit,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
       sym_char_lit,
       sym_bool_lit,
       anon_sym_SLASH,
       anon_sym_LPAREN,
       anon_sym_RPAREN,
-      anon_sym_SQUOTE,
       anon_sym_BQUOTE,
       anon_sym_COMMA_AT,
-  [375] = 2,
-    ACTIONS(232), 3,
+  [1482] = 2,
+    ACTIONS(239), 3,
+      anon_sym_COMMA,
       sym_null_lit,
       aux_sym__sym_unqualified_token1,
-      anon_sym_COMMA,
-    ACTIONS(230), 14,
+    ACTIONS(237), 15,
+      ts_builtin_sym_end,
       sym__ws,
       sym_comment,
-      anon_sym_POUND_PIPE,
-      sym_num_lit,
+      sym_block_comment,
+      aux_sym_num_lit_token1,
       anon_sym_COLON,
-      sym_str_lit,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
       sym_char_lit,
       sym_bool_lit,
       anon_sym_SLASH,
       anon_sym_LPAREN,
       anon_sym_RPAREN,
-      anon_sym_SQUOTE,
       anon_sym_BQUOTE,
       anon_sym_COMMA_AT,
-  [397] = 4,
-    ACTIONS(238), 1,
-      anon_sym_PIPE_POUND,
-    STATE(33), 1,
-      aux_sym_comment_multiline_repeat1,
-    ACTIONS(234), 2,
-      aux_sym_comment_multiline_token1,
-      aux_sym_comment_multiline_token4,
-    ACTIONS(236), 2,
-      aux_sym_comment_multiline_token2,
-      aux_sym_comment_multiline_token3,
-  [412] = 4,
-    ACTIONS(244), 1,
-      anon_sym_PIPE_POUND,
-    STATE(34), 1,
-      aux_sym_comment_multiline_repeat1,
-    ACTIONS(240), 2,
-      aux_sym_comment_multiline_token1,
-      aux_sym_comment_multiline_token4,
-    ACTIONS(242), 2,
-      aux_sym_comment_multiline_token2,
-      aux_sym_comment_multiline_token3,
-  [427] = 4,
-    ACTIONS(252), 1,
-      anon_sym_PIPE_POUND,
-    STATE(34), 1,
-      aux_sym_comment_multiline_repeat1,
-    ACTIONS(246), 2,
-      aux_sym_comment_multiline_token1,
-      aux_sym_comment_multiline_token4,
-    ACTIONS(249), 2,
-      aux_sym_comment_multiline_token2,
-      aux_sym_comment_multiline_token3,
-  [442] = 1,
-    ACTIONS(254), 1,
+  [1505] = 2,
+    ACTIONS(243), 3,
+      anon_sym_COMMA,
+      sym_null_lit,
+      aux_sym__sym_unqualified_token1,
+    ACTIONS(241), 15,
+      ts_builtin_sym_end,
+      sym__ws,
+      sym_comment,
+      sym_block_comment,
+      aux_sym_num_lit_token1,
+      anon_sym_COLON,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+      sym_char_lit,
+      sym_bool_lit,
+      anon_sym_SLASH,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_BQUOTE,
+      anon_sym_COMMA_AT,
+  [1528] = 2,
+    ACTIONS(247), 3,
+      anon_sym_COMMA,
+      sym_null_lit,
+      aux_sym__sym_unqualified_token1,
+    ACTIONS(245), 15,
+      ts_builtin_sym_end,
+      sym__ws,
+      sym_comment,
+      sym_block_comment,
+      aux_sym_num_lit_token1,
+      anon_sym_COLON,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+      sym_char_lit,
+      sym_bool_lit,
+      anon_sym_SLASH,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_BQUOTE,
+      anon_sym_COMMA_AT,
+  [1551] = 2,
+    ACTIONS(251), 3,
+      anon_sym_COMMA,
+      sym_null_lit,
+      aux_sym__sym_unqualified_token1,
+    ACTIONS(249), 15,
+      ts_builtin_sym_end,
+      sym__ws,
+      sym_comment,
+      sym_block_comment,
+      aux_sym_num_lit_token1,
+      anon_sym_COLON,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+      sym_char_lit,
+      sym_bool_lit,
+      anon_sym_SLASH,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_BQUOTE,
+      anon_sym_COMMA_AT,
+  [1574] = 2,
+    ACTIONS(255), 3,
+      anon_sym_COMMA,
+      sym_null_lit,
+      aux_sym__sym_unqualified_token1,
+    ACTIONS(253), 15,
+      ts_builtin_sym_end,
+      sym__ws,
+      sym_comment,
+      sym_block_comment,
+      aux_sym_num_lit_token1,
+      anon_sym_COLON,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+      sym_char_lit,
+      sym_bool_lit,
+      anon_sym_SLASH,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_BQUOTE,
+      anon_sym_COMMA_AT,
+  [1597] = 2,
+    ACTIONS(259), 3,
+      anon_sym_COMMA,
+      sym_null_lit,
+      aux_sym__sym_unqualified_token1,
+    ACTIONS(257), 15,
+      ts_builtin_sym_end,
+      sym__ws,
+      sym_comment,
+      sym_block_comment,
+      aux_sym_num_lit_token1,
+      anon_sym_COLON,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+      sym_char_lit,
+      sym_bool_lit,
+      anon_sym_SLASH,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_BQUOTE,
+      anon_sym_COMMA_AT,
+  [1620] = 2,
+    ACTIONS(263), 3,
+      anon_sym_COMMA,
+      sym_null_lit,
+      aux_sym__sym_unqualified_token1,
+    ACTIONS(261), 15,
+      ts_builtin_sym_end,
+      sym__ws,
+      sym_comment,
+      sym_block_comment,
+      aux_sym_num_lit_token1,
+      anon_sym_COLON,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+      sym_char_lit,
+      sym_bool_lit,
+      anon_sym_SLASH,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_BQUOTE,
+      anon_sym_COMMA_AT,
+  [1643] = 2,
+    ACTIONS(267), 3,
+      anon_sym_COMMA,
+      sym_null_lit,
+      aux_sym__sym_unqualified_token1,
+    ACTIONS(265), 15,
+      ts_builtin_sym_end,
+      sym__ws,
+      sym_comment,
+      sym_block_comment,
+      aux_sym_num_lit_token1,
+      anon_sym_COLON,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+      sym_char_lit,
+      sym_bool_lit,
+      anon_sym_SLASH,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_BQUOTE,
+      anon_sym_COMMA_AT,
+  [1666] = 2,
+    ACTIONS(271), 3,
+      anon_sym_COMMA,
+      sym_null_lit,
+      aux_sym__sym_unqualified_token1,
+    ACTIONS(269), 15,
+      ts_builtin_sym_end,
+      sym__ws,
+      sym_comment,
+      sym_block_comment,
+      aux_sym_num_lit_token1,
+      anon_sym_COLON,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+      sym_char_lit,
+      sym_bool_lit,
+      anon_sym_SLASH,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_BQUOTE,
+      anon_sym_COMMA_AT,
+  [1689] = 2,
+    ACTIONS(275), 3,
+      anon_sym_COMMA,
+      sym_null_lit,
+      aux_sym__sym_unqualified_token1,
+    ACTIONS(273), 14,
+      sym__ws,
+      sym_comment,
+      sym_block_comment,
+      aux_sym_num_lit_token1,
+      anon_sym_COLON,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+      sym_char_lit,
+      sym_bool_lit,
+      anon_sym_SLASH,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+      anon_sym_BQUOTE,
+      anon_sym_COMMA_AT,
+  [1711] = 2,
+    ACTIONS(279), 2,
+      anon_sym_COLON,
+      anon_sym_AT,
+    ACTIONS(277), 11,
+      aux_sym_num_lit_token1,
+      anon_sym_SQUOTE,
+      anon_sym_COMMA,
+      anon_sym_AT_COLON,
+      anon_sym_COLON_AT,
+      anon_sym_TILDE,
+      anon_sym_PERCENT,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      anon_sym_STAR,
+      aux_sym_format_directive_type_token11,
+  [1729] = 4,
+    ACTIONS(287), 1,
+      anon_sym_STAR,
+    ACTIONS(283), 2,
+      anon_sym_COLON,
+      anon_sym_AT,
+    ACTIONS(285), 4,
+      anon_sym_TILDE,
+      anon_sym_PERCENT,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+    ACTIONS(281), 6,
+      aux_sym_num_lit_token1,
+      anon_sym_SQUOTE,
+      anon_sym_COMMA,
+      anon_sym_AT_COLON,
+      anon_sym_COLON_AT,
+      aux_sym_format_directive_type_token11,
+  [1751] = 2,
+    ACTIONS(291), 2,
+      anon_sym_COLON,
+      anon_sym_AT,
+    ACTIONS(289), 11,
+      aux_sym_num_lit_token1,
+      anon_sym_SQUOTE,
+      anon_sym_COMMA,
+      anon_sym_AT_COLON,
+      anon_sym_COLON_AT,
+      anon_sym_TILDE,
+      anon_sym_PERCENT,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      anon_sym_STAR,
+      aux_sym_format_directive_type_token11,
+  [1769] = 7,
+    ACTIONS(29), 1,
+      aux_sym_num_lit_token1,
+    ACTIONS(33), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(295), 1,
+      anon_sym_COMMA,
+    ACTIONS(299), 1,
+      aux_sym_format_directive_type_token11,
+    ACTIONS(293), 2,
+      anon_sym_COLON,
+      anon_sym_AT,
+    ACTIONS(297), 2,
+      anon_sym_AT_COLON,
+      anon_sym_COLON_AT,
+    STATE(47), 2,
+      sym__format_token,
+      aux_sym_format_modifiers_repeat1,
+  [1794] = 6,
+    ACTIONS(301), 1,
+      aux_sym_num_lit_token1,
+    ACTIONS(306), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(309), 1,
+      anon_sym_COMMA,
+    ACTIONS(304), 2,
+      anon_sym_COLON,
+      anon_sym_AT,
+    STATE(47), 2,
+      sym__format_token,
+      aux_sym_format_modifiers_repeat1,
+    ACTIONS(312), 3,
+      anon_sym_AT_COLON,
+      anon_sym_COLON_AT,
+      aux_sym_format_directive_type_token11,
+  [1817] = 4,
+    ACTIONS(314), 1,
+      anon_sym_TILDE,
+    ACTIONS(317), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(319), 2,
+      aux_sym_str_lit_token1,
+      aux_sym_str_lit_token2,
+    STATE(48), 2,
+      sym_format_specifier,
+      aux_sym_str_lit_repeat1,
+  [1832] = 4,
+    ACTIONS(47), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(322), 1,
+      anon_sym_TILDE,
+    ACTIONS(324), 2,
+      aux_sym_str_lit_token1,
+      aux_sym_str_lit_token2,
+    STATE(48), 2,
+      sym_format_specifier,
+      aux_sym_str_lit_repeat1,
+  [1847] = 5,
+    ACTIONS(29), 1,
+      aux_sym_num_lit_token1,
+    ACTIONS(33), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(295), 1,
+      anon_sym_COMMA,
+    ACTIONS(299), 1,
+      aux_sym_format_directive_type_token11,
+    STATE(47), 2,
+      sym__format_token,
+      aux_sym_format_modifiers_repeat1,
+  [1864] = 4,
+    ACTIONS(326), 1,
+      anon_sym_TILDE,
+    ACTIONS(328), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(330), 2,
+      aux_sym_str_lit_token1,
+      aux_sym_str_lit_token2,
+    STATE(49), 2,
+      sym_format_specifier,
+      aux_sym_str_lit_repeat1,
+  [1879] = 1,
+    ACTIONS(332), 4,
+      anon_sym_TILDE,
+      anon_sym_DQUOTE,
+      aux_sym_str_lit_token1,
+      aux_sym_str_lit_token2,
+  [1886] = 1,
+    ACTIONS(334), 4,
+      anon_sym_TILDE,
+      anon_sym_DQUOTE,
+      aux_sym_str_lit_token1,
+      aux_sym_str_lit_token2,
+  [1893] = 1,
+    ACTIONS(336), 4,
+      anon_sym_TILDE,
+      anon_sym_DQUOTE,
+      aux_sym_str_lit_token1,
+      aux_sym_str_lit_token2,
+  [1900] = 1,
+    ACTIONS(338), 4,
+      anon_sym_TILDE,
+      anon_sym_DQUOTE,
+      aux_sym_str_lit_token1,
+      aux_sym_str_lit_token2,
+  [1907] = 1,
+    ACTIONS(340), 4,
+      anon_sym_TILDE,
+      anon_sym_DQUOTE,
+      aux_sym_str_lit_token1,
+      aux_sym_str_lit_token2,
+  [1914] = 1,
+    ACTIONS(342), 4,
+      anon_sym_TILDE,
+      anon_sym_DQUOTE,
+      aux_sym_str_lit_token1,
+      aux_sym_str_lit_token2,
+  [1921] = 1,
+    ACTIONS(344), 4,
+      anon_sym_TILDE,
+      anon_sym_DQUOTE,
+      aux_sym_str_lit_token1,
+      aux_sym_str_lit_token2,
+  [1928] = 1,
+    ACTIONS(346), 1,
       aux_sym__kwd_unqualified_token1,
-  [446] = 1,
-    ACTIONS(256), 1,
+  [1932] = 1,
+    ACTIONS(348), 1,
+      aux_sym__format_token_token1,
+  [1936] = 1,
+    ACTIONS(350), 1,
       ts_builtin_sym_end,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
-  [SMALL_STATE(15)] = 0,
-  [SMALL_STATE(16)] = 30,
-  [SMALL_STATE(17)] = 53,
-  [SMALL_STATE(18)] = 76,
-  [SMALL_STATE(19)] = 99,
-  [SMALL_STATE(20)] = 122,
-  [SMALL_STATE(21)] = 145,
-  [SMALL_STATE(22)] = 168,
-  [SMALL_STATE(23)] = 191,
-  [SMALL_STATE(24)] = 214,
-  [SMALL_STATE(25)] = 237,
-  [SMALL_STATE(26)] = 260,
-  [SMALL_STATE(27)] = 283,
-  [SMALL_STATE(28)] = 306,
-  [SMALL_STATE(29)] = 329,
-  [SMALL_STATE(30)] = 352,
-  [SMALL_STATE(31)] = 375,
-  [SMALL_STATE(32)] = 397,
-  [SMALL_STATE(33)] = 412,
-  [SMALL_STATE(34)] = 427,
-  [SMALL_STATE(35)] = 442,
-  [SMALL_STATE(36)] = 446,
+  [SMALL_STATE(2)] = 0,
+  [SMALL_STATE(3)] = 66,
+  [SMALL_STATE(4)] = 132,
+  [SMALL_STATE(5)] = 195,
+  [SMALL_STATE(6)] = 248,
+  [SMALL_STATE(7)] = 312,
+  [SMALL_STATE(8)] = 380,
+  [SMALL_STATE(9)] = 448,
+  [SMALL_STATE(10)] = 516,
+  [SMALL_STATE(11)] = 580,
+  [SMALL_STATE(12)] = 645,
+  [SMALL_STATE(13)] = 710,
+  [SMALL_STATE(14)] = 775,
+  [SMALL_STATE(15)] = 840,
+  [SMALL_STATE(16)] = 905,
+  [SMALL_STATE(17)] = 970,
+  [SMALL_STATE(18)] = 1035,
+  [SMALL_STATE(19)] = 1100,
+  [SMALL_STATE(20)] = 1133,
+  [SMALL_STATE(21)] = 1175,
+  [SMALL_STATE(22)] = 1217,
+  [SMALL_STATE(23)] = 1244,
+  [SMALL_STATE(24)] = 1271,
+  [SMALL_STATE(25)] = 1294,
+  [SMALL_STATE(26)] = 1317,
+  [SMALL_STATE(27)] = 1340,
+  [SMALL_STATE(28)] = 1363,
+  [SMALL_STATE(29)] = 1386,
+  [SMALL_STATE(30)] = 1409,
+  [SMALL_STATE(31)] = 1432,
+  [SMALL_STATE(32)] = 1459,
+  [SMALL_STATE(33)] = 1482,
+  [SMALL_STATE(34)] = 1505,
+  [SMALL_STATE(35)] = 1528,
+  [SMALL_STATE(36)] = 1551,
+  [SMALL_STATE(37)] = 1574,
+  [SMALL_STATE(38)] = 1597,
+  [SMALL_STATE(39)] = 1620,
+  [SMALL_STATE(40)] = 1643,
+  [SMALL_STATE(41)] = 1666,
+  [SMALL_STATE(42)] = 1689,
+  [SMALL_STATE(43)] = 1711,
+  [SMALL_STATE(44)] = 1729,
+  [SMALL_STATE(45)] = 1751,
+  [SMALL_STATE(46)] = 1769,
+  [SMALL_STATE(47)] = 1794,
+  [SMALL_STATE(48)] = 1817,
+  [SMALL_STATE(49)] = 1832,
+  [SMALL_STATE(50)] = 1847,
+  [SMALL_STATE(51)] = 1864,
+  [SMALL_STATE(52)] = 1879,
+  [SMALL_STATE(53)] = 1886,
+  [SMALL_STATE(54)] = 1893,
+  [SMALL_STATE(55)] = 1900,
+  [SMALL_STATE(56)] = 1907,
+  [SMALL_STATE(57)] = 1914,
+  [SMALL_STATE(58)] = 1921,
+  [SMALL_STATE(59)] = 1928,
+  [SMALL_STATE(60)] = 1932,
+  [SMALL_STATE(61)] = 1936,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source, 0),
-  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
-  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
-  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
-  [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(6),
-  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
-  [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(27),
-  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
-  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
-  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
-  [25] = {.entry = {.count = 1, .reusable = false}}, SHIFT(10),
-  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
-  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
-  [31] = {.entry = {.count = 1, .reusable = false}}, SHIFT(31),
-  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
-  [35] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__bare_list_lit_repeat1, 2, .production_id = 8), SHIFT_REPEAT(3),
-  [38] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__bare_list_lit_repeat1, 2, .production_id = 8), SHIFT_REPEAT(32),
-  [41] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__bare_list_lit_repeat1, 2, .production_id = 8), SHIFT_REPEAT(31),
-  [44] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__bare_list_lit_repeat1, 2, .production_id = 8), SHIFT_REPEAT(35),
-  [47] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__bare_list_lit_repeat1, 2, .production_id = 8), SHIFT_REPEAT(31),
-  [50] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__bare_list_lit_repeat1, 2, .production_id = 8), SHIFT_REPEAT(27),
-  [53] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__bare_list_lit_repeat1, 2, .production_id = 8), SHIFT_REPEAT(27),
-  [56] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__bare_list_lit_repeat1, 2, .production_id = 8), SHIFT_REPEAT(4),
-  [59] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__bare_list_lit_repeat1, 2, .production_id = 8),
-  [61] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__bare_list_lit_repeat1, 2, .production_id = 8), SHIFT_REPEAT(7),
-  [64] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__bare_list_lit_repeat1, 2, .production_id = 8), SHIFT_REPEAT(8),
-  [67] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__bare_list_lit_repeat1, 2, .production_id = 8), SHIFT_REPEAT(9),
-  [70] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__bare_list_lit_repeat1, 2, .production_id = 8), SHIFT_REPEAT(10),
-  [73] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
-  [75] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [77] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_repeat1, 2),
-  [79] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_repeat1, 2), SHIFT_REPEAT(5),
-  [82] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_repeat1, 2), SHIFT_REPEAT(32),
-  [85] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_repeat1, 2), SHIFT_REPEAT(35),
-  [88] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_repeat1, 2), SHIFT_REPEAT(5),
-  [91] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_repeat1, 2), SHIFT_REPEAT(27),
-  [94] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_repeat1, 2), SHIFT_REPEAT(27),
-  [97] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_repeat1, 2), SHIFT_REPEAT(4),
-  [100] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_repeat1, 2), SHIFT_REPEAT(7),
-  [103] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_repeat1, 2), SHIFT_REPEAT(8),
-  [106] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_repeat1, 2), SHIFT_REPEAT(9),
-  [109] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_repeat1, 2), SHIFT_REPEAT(10),
-  [112] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source, 1),
-  [114] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
-  [116] = {.entry = {.count = 1, .reusable = false}}, SHIFT(5),
-  [118] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
-  [120] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
-  [122] = {.entry = {.count = 1, .reusable = false}}, SHIFT(16),
-  [124] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
-  [126] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
-  [128] = {.entry = {.count = 1, .reusable = false}}, SHIFT(18),
-  [130] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
-  [132] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
-  [134] = {.entry = {.count = 1, .reusable = false}}, SHIFT(19),
-  [136] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
-  [138] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
-  [140] = {.entry = {.count = 1, .reusable = false}}, SHIFT(21),
-  [142] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
-  [144] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
-  [146] = {.entry = {.count = 1, .reusable = false}}, SHIFT(30),
-  [148] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
-  [150] = {.entry = {.count = 1, .reusable = false}}, SHIFT(29),
-  [152] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [154] = {.entry = {.count = 1, .reusable = false}}, SHIFT(28),
-  [156] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
-  [158] = {.entry = {.count = 1, .reusable = false}}, SHIFT(26),
-  [160] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_quoting_lit_repeat1, 2), SHIFT_REPEAT(15),
-  [163] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_quoting_lit_repeat1, 2), SHIFT_REPEAT(32),
-  [166] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_quoting_lit_repeat1, 2),
-  [168] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_quoting_lit_repeat1, 2),
-  [170] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_quoting_lit, 2, .production_id = 5),
-  [172] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_quoting_lit, 2, .production_id = 5),
-  [174] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__bare_list_lit, 2, .production_id = 3),
-  [176] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__bare_list_lit, 2, .production_id = 3),
-  [178] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_quasi_quoting_lit, 2, .production_id = 5),
-  [180] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_quasi_quoting_lit, 2, .production_id = 5),
-  [182] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_unquote_splicing_lit, 2, .production_id = 5),
-  [184] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_unquote_splicing_lit, 2, .production_id = 5),
-  [186] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment_multiline, 2),
-  [188] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_comment_multiline, 2),
-  [190] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_unquoting_lit, 2, .production_id = 5),
-  [192] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_unquoting_lit, 2, .production_id = 5),
-  [194] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_list_lit, 1, .production_id = 2),
-  [196] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_list_lit, 1, .production_id = 2),
-  [198] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_kwd_lit, 2, .production_id = 6),
-  [200] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_kwd_lit, 2, .production_id = 6),
-  [202] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment_multiline, 3),
-  [204] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_comment_multiline, 3),
-  [206] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__bare_list_lit, 3, .production_id = 7),
-  [208] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__bare_list_lit, 3, .production_id = 7),
-  [210] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_quoting_lit, 3, .production_id = 9),
-  [212] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_quoting_lit, 3, .production_id = 9),
-  [214] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_sym_lit, 1, .production_id = 1),
-  [216] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_sym_lit, 1, .production_id = 1),
-  [218] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_quasi_quoting_lit, 3, .production_id = 9),
-  [220] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_quasi_quoting_lit, 3, .production_id = 9),
-  [222] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_unquote_splicing_lit, 3, .production_id = 9),
-  [224] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_unquote_splicing_lit, 3, .production_id = 9),
-  [226] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_unquoting_lit, 3, .production_id = 9),
-  [228] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_unquoting_lit, 3, .production_id = 9),
-  [230] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__bare_list_lit_repeat1, 1, .production_id = 4),
-  [232] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__bare_list_lit_repeat1, 1, .production_id = 4),
-  [234] = {.entry = {.count = 1, .reusable = false}}, SHIFT(33),
-  [236] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
-  [238] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
-  [240] = {.entry = {.count = 1, .reusable = false}}, SHIFT(34),
-  [242] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
-  [244] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
-  [246] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_comment_multiline_repeat1, 2), SHIFT_REPEAT(34),
-  [249] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comment_multiline_repeat1, 2), SHIFT_REPEAT(34),
-  [252] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_comment_multiline_repeat1, 2),
-  [254] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
-  [256] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
+  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
+  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
+  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(12),
+  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
+  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(10),
+  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
+  [21] = {.entry = {.count = 1, .reusable = false}}, SHIFT(37),
+  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
+  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
+  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
+  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
+  [31] = {.entry = {.count = 1, .reusable = false}}, SHIFT(22),
+  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
+  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
+  [37] = {.entry = {.count = 1, .reusable = false}}, SHIFT(19),
+  [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
+  [41] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
+  [43] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
+  [45] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
+  [47] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
+  [49] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_repeat1, 2),
+  [51] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_repeat1, 2), SHIFT_REPEAT(6),
+  [54] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_repeat1, 2), SHIFT_REPEAT(34),
+  [57] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_repeat1, 2), SHIFT_REPEAT(59),
+  [60] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_repeat1, 2), SHIFT_REPEAT(11),
+  [63] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_repeat1, 2), SHIFT_REPEAT(12),
+  [66] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_repeat1, 2), SHIFT_REPEAT(51),
+  [69] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_repeat1, 2), SHIFT_REPEAT(6),
+  [72] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_repeat1, 2), SHIFT_REPEAT(37),
+  [75] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_repeat1, 2), SHIFT_REPEAT(37),
+  [78] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_repeat1, 2), SHIFT_REPEAT(8),
+  [81] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_repeat1, 2), SHIFT_REPEAT(13),
+  [84] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_repeat1, 2), SHIFT_REPEAT(14),
+  [87] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+  [89] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
+  [91] = {.entry = {.count = 1, .reusable = false}}, SHIFT(42),
+  [93] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [95] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
+  [97] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
+  [99] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__bare_list_lit_repeat1, 2, .production_id = 10), SHIFT_REPEAT(9),
+  [102] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__bare_list_lit_repeat1, 2, .production_id = 10), SHIFT_REPEAT(34),
+  [105] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__bare_list_lit_repeat1, 2, .production_id = 10), SHIFT_REPEAT(59),
+  [108] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__bare_list_lit_repeat1, 2, .production_id = 10), SHIFT_REPEAT(11),
+  [111] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__bare_list_lit_repeat1, 2, .production_id = 10), SHIFT_REPEAT(12),
+  [114] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__bare_list_lit_repeat1, 2, .production_id = 10), SHIFT_REPEAT(51),
+  [117] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__bare_list_lit_repeat1, 2, .production_id = 10), SHIFT_REPEAT(42),
+  [120] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__bare_list_lit_repeat1, 2, .production_id = 10), SHIFT_REPEAT(42),
+  [123] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__bare_list_lit_repeat1, 2, .production_id = 10), SHIFT_REPEAT(37),
+  [126] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__bare_list_lit_repeat1, 2, .production_id = 10), SHIFT_REPEAT(37),
+  [129] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__bare_list_lit_repeat1, 2, .production_id = 10), SHIFT_REPEAT(8),
+  [132] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__bare_list_lit_repeat1, 2, .production_id = 10),
+  [134] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__bare_list_lit_repeat1, 2, .production_id = 10), SHIFT_REPEAT(13),
+  [137] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__bare_list_lit_repeat1, 2, .production_id = 10), SHIFT_REPEAT(14),
+  [140] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source, 1),
+  [142] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
+  [144] = {.entry = {.count = 1, .reusable = false}}, SHIFT(6),
+  [146] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
+  [148] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
+  [150] = {.entry = {.count = 1, .reusable = false}}, SHIFT(41),
+  [152] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [154] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
+  [156] = {.entry = {.count = 1, .reusable = false}}, SHIFT(40),
+  [158] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [160] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
+  [162] = {.entry = {.count = 1, .reusable = false}}, SHIFT(28),
+  [164] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [166] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
+  [168] = {.entry = {.count = 1, .reusable = false}}, SHIFT(29),
+  [170] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
+  [172] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
+  [174] = {.entry = {.count = 1, .reusable = false}}, SHIFT(39),
+  [176] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
+  [178] = {.entry = {.count = 1, .reusable = false}}, SHIFT(24),
+  [180] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
+  [182] = {.entry = {.count = 1, .reusable = false}}, SHIFT(32),
+  [184] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
+  [186] = {.entry = {.count = 1, .reusable = false}}, SHIFT(27),
+  [188] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_format_prefix_parameters, 1),
+  [190] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_format_prefix_parameters, 1),
+  [192] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
+  [194] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_format_modifiers, 1),
+  [196] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_format_modifiers, 2),
+  [198] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_quoting_lit, 3, .production_id = 7),
+  [200] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_quoting_lit, 3, .production_id = 7),
+  [202] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_str_lit, 4),
+  [204] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_str_lit, 4),
+  [206] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__bare_list_lit, 2, .production_id = 4),
+  [208] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__bare_list_lit, 2, .production_id = 4),
+  [210] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_quasi_quoting_lit, 3, .production_id = 7),
+  [212] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_quasi_quoting_lit, 3, .production_id = 7),
+  [214] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_quasi_quoting_lit, 2, .production_id = 3),
+  [216] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_quasi_quoting_lit, 2, .production_id = 3),
+  [218] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_unquote_splicing_lit, 2, .production_id = 3),
+  [220] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_unquote_splicing_lit, 2, .production_id = 3),
+  [222] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_kwd_lit, 2, .production_id = 6),
+  [224] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_kwd_lit, 2, .production_id = 6),
+  [226] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_quoting_lit_repeat1, 2), SHIFT_REPEAT(31),
+  [229] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_quoting_lit_repeat1, 2),
+  [231] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_quoting_lit_repeat1, 2),
+  [233] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_unquoting_lit, 3, .production_id = 7),
+  [235] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_unquoting_lit, 3, .production_id = 7),
+  [237] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_list_lit, 1, .production_id = 2),
+  [239] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_list_lit, 1, .production_id = 2),
+  [241] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_num_lit, 1),
+  [243] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_num_lit, 1),
+  [245] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__bare_list_lit, 3, .production_id = 9),
+  [247] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__bare_list_lit, 3, .production_id = 9),
+  [249] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_str_lit, 2),
+  [251] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_str_lit, 2),
+  [253] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_sym_lit, 1, .production_id = 1),
+  [255] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_sym_lit, 1, .production_id = 1),
+  [257] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_str_lit, 3),
+  [259] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_str_lit, 3),
+  [261] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_unquote_splicing_lit, 3, .production_id = 7),
+  [263] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_unquote_splicing_lit, 3, .production_id = 7),
+  [265] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_unquoting_lit, 2, .production_id = 3),
+  [267] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_unquoting_lit, 2, .production_id = 3),
+  [269] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_quoting_lit, 2, .production_id = 3),
+  [271] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_quoting_lit, 2, .production_id = 3),
+  [273] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__bare_list_lit_repeat1, 1, .production_id = 5),
+  [275] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__bare_list_lit_repeat1, 1, .production_id = 5),
+  [277] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__format_token, 2),
+  [279] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__format_token, 2),
+  [281] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_format_modifiers_repeat1, 1),
+  [283] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_format_modifiers_repeat1, 1),
+  [285] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
+  [287] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
+  [289] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__format_token, 1, .production_id = 8),
+  [291] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__format_token, 1, .production_id = 8),
+  [293] = {.entry = {.count = 1, .reusable = false}}, SHIFT(23),
+  [295] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
+  [297] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
+  [299] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
+  [301] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_format_modifiers_repeat1, 2), SHIFT_REPEAT(45),
+  [304] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_format_modifiers_repeat1, 2),
+  [306] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_format_modifiers_repeat1, 2), SHIFT_REPEAT(60),
+  [309] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_format_modifiers_repeat1, 2), SHIFT_REPEAT(47),
+  [312] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_format_modifiers_repeat1, 2),
+  [314] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_str_lit_repeat1, 2), SHIFT_REPEAT(4),
+  [317] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_str_lit_repeat1, 2),
+  [319] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_str_lit_repeat1, 2), SHIFT_REPEAT(48),
+  [322] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
+  [324] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
+  [326] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
+  [328] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
+  [330] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
+  [332] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_format_directive_type, 2, .production_id = 11),
+  [334] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_format_directive_type, 2, .production_id = 12),
+  [336] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_format_specifier, 3),
+  [338] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_format_specifier, 2),
+  [340] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_format_directive_type, 2),
+  [342] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_format_directive_type, 1),
+  [344] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_format_specifier, 4),
+  [346] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
+  [348] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
+  [350] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
 };
 
 #ifdef __cplusplus

--- a/test/corpus/comment_lit.txt
+++ b/test/corpus/comment_lit.txt
@@ -46,7 +46,7 @@ that spans multiple lines
 --------------------------------------------------------------------------------
 
 (source
-  (comment_multiline)
+  (block_comment)
   (comment))
 
 ================================================================================
@@ -60,7 +60,7 @@ that spans multiple lines
 --------------------------------------------------------------------------------
 
 (source
-  (comment_multiline))
+  (block_comment))
 
 ================================================================================
 Multi-line Block Comment Content also on Second Line
@@ -72,4 +72,4 @@ that spans multiple lines|#
 --------------------------------------------------------------------------------
 
 (source
-  (comment_multiline))
+  (block_comment))

--- a/test/corpus/format.txt
+++ b/test/corpus/format.txt
@@ -1,0 +1,37 @@
+================================================================================
+Format - Basic Case
+================================================================================
+
+"~S~D"
+
+---
+
+(source
+  (str_lit
+    (format_specifier
+      (format_directive_type))
+    (format_specifier
+      (format_directive_type))))
+
+================================================================================
+Format - In an Actual Call
+================================================================================
+
+(format 0 "~S~D" string-var int-var)
+
+---
+
+(source
+  (list_lit
+    (sym_lit
+      (sym_name))
+    (num_lit)
+    (str_lit
+      (format_specifier
+        (format_directive_type))
+      (format_specifier
+        (format_directive_type)))
+    (sym_lit
+      (sym_name))
+    (sym_lit
+      (sym_name))))


### PR DESCRIPTION
Adds support for `format` string directives.  This is likely missing some that are relevant to OpenGOAL -- I'll iron it out and remove the irrelevant parts from the grammar as I use it.